### PR TITLE
feat(htmltoslate): support line breaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "domutils": "^3.0.1",
         "html-escaper": "^3.0.3",
         "htmlparser2": "^8.0.1",
+        "slate": "^0.86.0",
         "slate-hyperscript": "^0.77.0"
       },
       "devDependencies": {
@@ -4234,7 +4235,6 @@
       "version": "9.0.16",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.16.tgz",
       "integrity": "sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -7682,7 +7682,6 @@
       "version": "0.86.0",
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.86.0.tgz",
       "integrity": "sha512-aexL720Tpqx6St5oz0jo0/wZWCT7z8lChKkVJo2eiFkSNmoSnCGR62d2itAvmse7dEXkl4DbfAxRQPj8JDuGTg==",
-      "peer": true,
       "dependencies": {
         "immer": "^9.0.6",
         "is-plain-object": "^5.0.0",
@@ -8032,8 +8031,7 @@
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "peer": true
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -11809,8 +11807,7 @@
     "immer": {
       "version": "9.0.16",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.16.tgz",
-      "integrity": "sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ==",
-      "peer": true
+      "integrity": "sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -14382,7 +14379,6 @@
       "version": "0.86.0",
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.86.0.tgz",
       "integrity": "sha512-aexL720Tpqx6St5oz0jo0/wZWCT7z8lChKkVJo2eiFkSNmoSnCGR62d2itAvmse7dEXkl4DbfAxRQPj8JDuGTg==",
-      "peer": true,
       "requires": {
         "immer": "^9.0.6",
         "is-plain-object": "^5.0.0",
@@ -14669,8 +14665,7 @@
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "peer": true
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "domutils": "^3.0.1",
     "html-escaper": "^3.0.3",
     "htmlparser2": "^8.0.1",
+    "slate": "^0.86.0",
     "slate-hyperscript": "^0.77.0"
   }
 }

--- a/src/__tests__/fixtures/combined.ts
+++ b/src/__tests__/fixtures/combined.ts
@@ -79,6 +79,118 @@ export const fixtures: Ifixture[] = [
       },
     ],
   },
+  /**
+   * this is an interesting test - note the line break
+   * included by Slate. We need to support this in
+   * reserialized Slate in order to get matching HTML
+   *  */
+  {
+    name: 'links nested in an unordered list',
+    html: `<ul><li><a href="https://support.teamtailor.com/en/articles/1908751-gdpr-features" target="_blank">GDPR features | Teamtailor Support</a></li><li><a href="https://support.teamtailor.com/en/articles/2834603-candidate-data-and-privacy-feature" target="_blank">Candidate Data and Privacy feature | Teamtailor Support</a>
+</li></ul>`,
+    slateOriginal: [
+      {
+        type: 'ul',
+        children: [
+          {
+            children: [
+              {
+                text: '',
+              },
+              {
+                type: 'link',
+                linkType: 'custom',
+                url: 'https://support.teamtailor.com/en/articles/1908751-gdpr-features',
+                newTab: true,
+                children: [
+                  {
+                    text: 'GDPR features | Teamtailor Support',
+                  },
+                ],
+              },
+              {
+                text: '',
+              },
+            ],
+            type: 'li',
+          },
+          {
+            type: 'li',
+            children: [
+              {
+                text: '',
+              },
+              {
+                type: 'link',
+                linkType: 'custom',
+                url: 'https://support.teamtailor.com/en/articles/2834603-candidate-data-and-privacy-feature',
+                newTab: true,
+                children: [
+                  {
+                    text: 'Candidate Data and Privacy feature | Teamtailor Support',
+                  },
+                ],
+              },
+              {
+                text: '\n',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    slateReserialized: [
+      {
+        type: 'ul',
+        children: [
+          {
+            children: [
+              /*{
+                text: '',
+              },*/
+              {
+                type: 'link',
+                //linkType: 'custom',
+                url: 'https://support.teamtailor.com/en/articles/1908751-gdpr-features',
+                newTab: true,
+                children: [
+                  {
+                    text: 'GDPR features | Teamtailor Support',
+                  },
+                ],
+              },
+              /*{
+                text: '',
+              },*/
+            ],
+            type: 'li',
+          },
+          {
+            type: 'li',
+            children: [
+              /*{
+                text: '',
+              },*/
+              {
+                type: 'link',
+                //linkType: 'custom',
+                url: 'https://support.teamtailor.com/en/articles/2834603-candidate-data-and-privacy-feature',
+                newTab: true,
+                children: [
+                  {
+                    text: 'Candidate Data and Privacy feature | Teamtailor Support',
+                  },
+                ],
+              },
+              {
+                text: "\n",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
   {
     name: 'larger document 1',
     html: '<h2>Heading 2</h2><p>A regular paragraph.</p><p>A <strong>paragraph</strong> with <strong><i>various</i></strong> text <s>marks</s>.</p><h3>Heading 3</h3><ul><li><strong>Item 1</strong>: From a list</li><li><strong>Item 2</strong>: From a list</li></ul><p><a href="https://docs.slatejs.org/">Find out more about Slate</a>.</p><h4>Heading 4</h4>',

--- a/src/__tests__/fixtures/combined.ts
+++ b/src/__tests__/fixtures/combined.ts
@@ -183,7 +183,7 @@ export const fixtures: Ifixture[] = [
                 ],
               },
               {
-                text: "\n",
+                text: '\n',
               },
             ],
           },

--- a/src/serializers/htmlToSlate/index.spec.ts
+++ b/src/serializers/htmlToSlate/index.spec.ts
@@ -18,6 +18,13 @@ describe('Housekeeping', () => {
       {
         children: [
           {
+            text: '\n    ',
+          },
+        ],
+      },
+      {
+        children: [
+          {
             text: 'Paragraph 1',
           },
         ],

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -1,7 +1,8 @@
 import { jsx } from 'slate-hyperscript'
 import { Parser, ElementType } from 'htmlparser2'
 import { ChildNode, DomHandler, Element } from 'domhandler'
-import { getAttributeValue, getChildren, getName, textContent } from 'domutils'
+import { getAttributeValue, getChildren, getInnerHTML, getName, textContent } from 'domutils'
+import render from "dom-serializer"
 import { removeLineBreaks } from '../../utilities'
 
 interface ItagMap {
@@ -61,7 +62,8 @@ const deserialize = (el: ChildNode, index?: number): any => {
   }
 
   if (TEXT_TAGS[nodeName] || el.type === ElementType.Text) {
-    if (textContent(el).trim() === '') {
+    const text = textContent(el)
+    if (text.match(/[\r\n]+/) === null && text.trim() === '') {
       return null
     }
     return [jsx('text', gatherTextMarkAttributes(parent), [])]
@@ -118,7 +120,8 @@ export const htmlToSlate = (html: string) => {
     }
   })
   const parser = new Parser(handler)
-  parser.write(removeLineBreaks(html))
+  //parser.write(removeLineBreaks(html))
+  parser.write(html)
   parser.end()
   return slateContent
 }

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -1,7 +1,7 @@
 import { jsx } from 'slate-hyperscript'
 import { Parser, ElementType } from 'htmlparser2'
 import { ChildNode, DomHandler, Element } from 'domhandler'
-import { getAttributeValue, getChildren, getInnerHTML, getName, textContent } from 'domutils'
+import { getAttributeValue, getChildren, getName, textContent } from 'domutils'
 import { hasLineBreak } from '../../utilities'
 
 interface ItagMap {

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -2,8 +2,7 @@ import { jsx } from 'slate-hyperscript'
 import { Parser, ElementType } from 'htmlparser2'
 import { ChildNode, DomHandler, Element } from 'domhandler'
 import { getAttributeValue, getChildren, getInnerHTML, getName, textContent } from 'domutils'
-import render from "dom-serializer"
-import { removeLineBreaks } from '../../utilities'
+import { hasLineBreak } from '../../utilities'
 
 interface ItagMap {
   [key: string]: (a?: Element) => object
@@ -63,7 +62,7 @@ const deserialize = (el: ChildNode, index?: number): any => {
 
   if (TEXT_TAGS[nodeName] || el.type === ElementType.Text) {
     const text = textContent(el)
-    if (text.match(/[\r\n]+/) === null && text.trim() === '') {
+    if (!hasLineBreak(text) && text.trim() === '') {
       return null
     }
     return [jsx('text', gatherTextMarkAttributes(parent), [])]
@@ -120,7 +119,6 @@ export const htmlToSlate = (html: string) => {
     }
   })
   const parser = new Parser(handler)
-  //parser.write(removeLineBreaks(html))
   parser.write(html)
   parser.end()
   return slateContent

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,1 +1,1 @@
-export const removeLineBreaks = (str: string) => str.replace(/(\r\n|\n|\r)/gm, '')
+export const hasLineBreak = (str: string) => str.match(/[\r\n]+/) !== null


### PR DESCRIPTION
Original Slate JSON objects can contain line breaks in `text` fields. These line breaks are important for formatting. e.g. they may be used instead of a paragraph tag to form a new line. Make sure they are supported by both `htmlToSlate` and `slateToHtml`.