### PR TITLE
feat(*): support custom attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,55 @@ const serializedToHtml = slateToHtml(slate)
 const serializedToSlate = htmlToSlate(serializedToHtml)
 ```
 
+Both serializers support an `attributeMap` option, which maps Slate attributes to HTML attributes and vice versa. This is supported for element tags only.
+
+```ts
+const slate = [
+  {
+    children: [
+      {
+        type: 'link',
+        "linkType": "custom",
+        url: 'https://github.com/thompsonsj/slate-serializers',
+        newTab: true,
+        children: [
+          {
+            text: 'slate-serializers | GitHub',
+          },
+        ],
+      },
+    ],
+    type: 'p',
+  }
+]
+
+const html = slateToHtml(slate,
+  {
+    attributeMap: [
+      {
+        slateAttr: 'linkType',
+        htmlAttr: 'data-link-type'
+      } 
+    ]
+  }
+)
+
+// output
+// <p><a href="https://github.com/thompsonsj/slate-serializers" target="_blank" data-link-type="custom">slate-serializers | GitHub</a></p>
+
+// using the same attributeMap for htmlToSlate will ensure the linkType attribute is preserved in the Slate JSON object.
+const slateReserialized = htmlToSlate(html,
+  {
+    attributeMap: [
+      {
+        slateAttr: 'linkType',
+        htmlAttr: 'data-link-type'
+      } 
+    ]
+  }
+)
+```
+
 ## Details
 
 ### slateToHtml

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const slate = [
     children: [
       {
         type: 'link',
-        "linkType": "custom",
+        linkType: "custom",
         url: 'https://github.com/thompsonsj/slate-serializers',
         newTab: true,
         children: [

--- a/src/__tests__/combined.spec.ts
+++ b/src/__tests__/combined.spec.ts
@@ -23,7 +23,7 @@ describe('attribute mapping', () => {
         },
         {
           type: 'link',
-          "linkType": "custom",
+          linkType: 'custom',
           url: 'https://github.com/thompsonsj/slate-serializers',
           newTab: true,
           children: [
@@ -37,25 +37,34 @@ describe('attribute mapping', () => {
         },
       ],
       type: 'p',
-    }
+    },
   ]
-  const html = '<p>Some text before an inline link <a href="https://github.com/thompsonsj/slate-serializers" target="_blank" data-link-type="custom">slate-serializers | GitHub</a>.</p>'
+  const html =
+    '<p>Some text before an inline link <a href="https://github.com/thompsonsj/slate-serializers" target="_blank" data-link-type="custom">slate-serializers | GitHub</a>.</p>'
 
   it('slateToHtml adds a custom data attribute', () => {
-    expect(slateToHtml(slate, {attributeMap: [
-      {
-        slateAttr: 'linkType',
-        htmlAttr: 'data-link-type'
-      } 
-    ]})).toEqual(html)
+    expect(
+      slateToHtml(slate, {
+        attributeMap: [
+          {
+            slateAttr: 'linkType',
+            htmlAttr: 'data-link-type',
+          },
+        ],
+      }),
+    ).toEqual(html)
   })
 
   it('htmlToSlate adds a custom data attribute', () => {
-    expect(htmlToSlate(html, {attributeMap: [
-      {
-        slateAttr: 'linkType',
-        htmlAttr: 'data-link-type'
-      } 
-    ]})).toEqual(slate)
+    expect(
+      htmlToSlate(html, {
+        attributeMap: [
+          {
+            slateAttr: 'linkType',
+            htmlAttr: 'data-link-type',
+          },
+        ],
+      }),
+    ).toEqual(slate)
   })
 })

--- a/src/__tests__/combined.spec.ts
+++ b/src/__tests__/combined.spec.ts
@@ -42,11 +42,20 @@ describe('attribute mapping', () => {
   const html = '<p>Some text before an inline link <a href="https://github.com/thompsonsj/slate-serializers" target="_blank" data-link-type="custom">slate-serializers | GitHub</a>.</p>'
 
   it('slateToHtml adds a custom data attribute', () => {
-    expect(slateToHtml(slate, {attributePropertyMap: [
+    expect(slateToHtml(slate, {attributeMap: [
       {
         slateAttr: 'linkType',
         htmlAttr: 'data-link-type'
       } 
     ]})).toEqual(html)
+  })
+
+  it('htmlToSlate adds a custom data attribute', () => {
+    expect(htmlToSlate(html, {attributeMap: [
+      {
+        slateAttr: 'linkType',
+        htmlAttr: 'data-link-type'
+      } 
+    ]})).toEqual(slate)
   })
 })

--- a/src/__tests__/combined.spec.ts
+++ b/src/__tests__/combined.spec.ts
@@ -13,3 +13,40 @@ describe('HTML to Slate JSON transforms', () => {
     }
   })
 })
+
+describe('attribute mapping', () => {
+  const slate = [
+    {
+      children: [
+        {
+          text: 'Some text before an inline link ',
+        },
+        {
+          type: 'link',
+          "linkType": "custom",
+          url: 'https://github.com/thompsonsj/slate-serializers',
+          newTab: true,
+          children: [
+            {
+              text: 'slate-serializers | GitHub',
+            },
+          ],
+        },
+        {
+          text: '.',
+        },
+      ],
+      type: 'p',
+    }
+  ]
+  const html = '<p>Some text before an inline link <a href="https://github.com/thompsonsj/slate-serializers" target="_blank" data-link-type="custom">slate-serializers | GitHub</a>.</p>'
+
+  it('slateToHtml adds a custom data attribute', () => {
+    expect(slateToHtml(slate, {attributePropertyMap: [
+      {
+        slateAttr: 'linkType',
+        htmlAttr: 'data-link-type'
+      } 
+    ]})).toEqual(html)
+  })
+})

--- a/src/__tests__/fixtures/combined.ts
+++ b/src/__tests__/fixtures/combined.ts
@@ -30,7 +30,7 @@ interface Ifixture {
 export const fixtures: Ifixture[] = [
   {
     name: 'text with inline link',
-    html: '<p>Some text before an inline link <a href="https://status.teamtailor.com" target="_blank">status.teamtailor.com</a>.</p>',
+    html: '<p>Some text before an inline link <a href="https://github.com/thompsonsj/slate-serializers" target="_blank">slate-serializers | GitHub</a>.</p>',
     slateOriginal: [
       {
         children: [
@@ -40,11 +40,11 @@ export const fixtures: Ifixture[] = [
           {
             type: 'link',
             linkType: 'custom',
-            url: 'https://status.teamtailor.com',
+            url: 'https://github.com/thompsonsj/slate-serializers',
             newTab: true,
             children: [
               {
-                text: 'status.teamtailor.com',
+                text: 'slate-serializers | GitHub',
               },
             ],
           },
@@ -63,11 +63,11 @@ export const fixtures: Ifixture[] = [
           {
             type: 'link',
             //"linkType": "custom", // this is payload specific?
-            url: 'https://status.teamtailor.com',
+            url: 'https://github.com/thompsonsj/slate-serializers',
             newTab: true,
             children: [
               {
-                text: 'status.teamtailor.com',
+                text: 'slate-serializers | GitHub',
               },
             ],
           },
@@ -86,7 +86,7 @@ export const fixtures: Ifixture[] = [
    *  */
   {
     name: 'links nested in an unordered list',
-    html: `<ul><li><a href="https://support.teamtailor.com/en/articles/1908751-gdpr-features" target="_blank">GDPR features | Teamtailor Support</a></li><li><a href="https://support.teamtailor.com/en/articles/2834603-candidate-data-and-privacy-feature" target="_blank">Candidate Data and Privacy feature | Teamtailor Support</a>
+    html: `<ul><li><a href="https://github.com/thompsonsj/slate-serializers" target="_blank">slate-serializers | GitHub</a></li><li><a href="https://github.com/thompsonsj/slate-serializers" target="_blank">slate-serializers | GitHub</a>
 </li></ul>`,
     slateOriginal: [
       {
@@ -100,11 +100,11 @@ export const fixtures: Ifixture[] = [
               {
                 type: 'link',
                 linkType: 'custom',
-                url: 'https://support.teamtailor.com/en/articles/1908751-gdpr-features',
+                url: 'https://github.com/thompsonsj/slate-serializers',
                 newTab: true,
                 children: [
                   {
-                    text: 'GDPR features | Teamtailor Support',
+                    text: 'slate-serializers | GitHub',
                   },
                 ],
               },
@@ -123,11 +123,11 @@ export const fixtures: Ifixture[] = [
               {
                 type: 'link',
                 linkType: 'custom',
-                url: 'https://support.teamtailor.com/en/articles/2834603-candidate-data-and-privacy-feature',
+                url: 'https://github.com/thompsonsj/slate-serializers',
                 newTab: true,
                 children: [
                   {
-                    text: 'Candidate Data and Privacy feature | Teamtailor Support',
+                    text: 'slate-serializers | GitHub',
                   },
                 ],
               },
@@ -151,11 +151,11 @@ export const fixtures: Ifixture[] = [
               {
                 type: 'link',
                 //linkType: 'custom',
-                url: 'https://support.teamtailor.com/en/articles/1908751-gdpr-features',
+                url: 'https://github.com/thompsonsj/slate-serializers',
                 newTab: true,
                 children: [
                   {
-                    text: 'GDPR features | Teamtailor Support',
+                    text: 'slate-serializers | GitHub',
                   },
                 ],
               },
@@ -174,11 +174,11 @@ export const fixtures: Ifixture[] = [
               {
                 type: 'link',
                 //linkType: 'custom',
-                url: 'https://support.teamtailor.com/en/articles/2834603-candidate-data-and-privacy-feature',
+                url: 'https://github.com/thompsonsj/slate-serializers',
                 newTab: true,
                 children: [
                   {
-                    text: 'Candidate Data and Privacy feature | Teamtailor Support',
+                    text: 'slate-serializers | GitHub',
                   },
                 ],
               },

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -39,11 +39,14 @@ const TEXT_TAGS: ItagMap = {
   u: () => ({ underline: true }),
 }
 
-const deserialize = (el: ChildNode, {
-  attributeMap = []
-}: {
-  attributeMap?: IattributeMap[]
-} = {}): any => {
+const deserialize = (
+  el: ChildNode,
+  {
+    attributeMap = [],
+  }: {
+    attributeMap?: IattributeMap[]
+  } = {},
+): any => {
   if (el.type !== ElementType.Tag && el.type !== ElementType.Text) {
     return null
   }
@@ -54,7 +57,7 @@ const deserialize = (el: ChildNode, {
 
   const nodeName = getName(parent)
 
-  const children = parent.childNodes ? parent.childNodes.map(node => deserialize(node, { attributeMap })).flat() : []
+  const children = parent.childNodes ? parent.childNodes.map((node) => deserialize(node, { attributeMap })).flat() : []
 
   if (getName(parent) === 'body') {
     return jsx('fragment', {}, children)
@@ -63,12 +66,12 @@ const deserialize = (el: ChildNode, {
   if (ELEMENT_TAGS[nodeName]) {
     let attrs = ELEMENT_TAGS[nodeName](parent)
     // tslint:disable-next-line no-unused-expression
-    attributeMap.map(map => {
+    attributeMap.map((map) => {
       const value = getAttributeValue(parent, map.htmlAttr)
       if (value) {
         attrs = {
           [map.slateAttr]: value,
-          ...attrs
+          ...attrs,
         }
       }
     })
@@ -112,11 +115,14 @@ const gatherTextMarkAttributes = (el: Element) => {
   return allAttrs
 }
 
-export const htmlToSlate = (html: string, {
-  attributeMap = []
-}: {
-  attributeMap?: IattributeMap[]
-} = {}) => {
+export const htmlToSlate = (
+  html: string,
+  {
+    attributeMap = [],
+  }: {
+    attributeMap?: IattributeMap[]
+  } = {},
+) => {
   let slateContent
   const handler = new DomHandler((error, dom) => {
     if (error) {

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -3,6 +3,7 @@ import { Parser, ElementType } from 'htmlparser2'
 import { ChildNode, DomHandler, Element } from 'domhandler'
 import { getAttributeValue, getChildren, getName, textContent } from 'domutils'
 import { hasLineBreak } from '../../utilities'
+import { IattributeMap } from '../../types'
 
 interface ItagMap {
   [key: string]: (a?: Element) => object
@@ -38,7 +39,11 @@ const TEXT_TAGS: ItagMap = {
   u: () => ({ underline: true }),
 }
 
-const deserialize = (el: ChildNode, index?: number): any => {
+const deserialize = (el: ChildNode, {
+  attributeMap = []
+}: {
+  attributeMap?: IattributeMap[]
+} = {}): any => {
   if (el.type !== ElementType.Tag && el.type !== ElementType.Text) {
     return null
   }
@@ -49,14 +54,24 @@ const deserialize = (el: ChildNode, index?: number): any => {
 
   const nodeName = getName(parent)
 
-  const children = parent.childNodes ? Array.from(parent.childNodes).map(deserialize).flat() : []
+  const children = parent.childNodes ? parent.childNodes.map(node => deserialize(node, { attributeMap })).flat() : []
 
   if (getName(parent) === 'body') {
     return jsx('fragment', {}, children)
   }
 
   if (ELEMENT_TAGS[nodeName]) {
-    const attrs = ELEMENT_TAGS[nodeName](parent)
+    let attrs = ELEMENT_TAGS[nodeName](parent)
+    // tslint:disable-next-line no-unused-expression
+    attributeMap.map(map => {
+      const value = getAttributeValue(parent, map.htmlAttr)
+      if (value) {
+        attrs = {
+          [map.slateAttr]: value,
+          ...attrs
+        }
+      }
+    })
     return jsx('element', attrs, children)
   }
 
@@ -97,7 +112,11 @@ const gatherTextMarkAttributes = (el: Element) => {
   return allAttrs
 }
 
-export const htmlToSlate = (html: string) => {
+export const htmlToSlate = (html: string, {
+  attributeMap = []
+}: {
+  attributeMap?: IattributeMap[]
+} = {}) => {
   let slateContent
   const handler = new DomHandler((error, dom) => {
     if (error) {
@@ -105,7 +124,7 @@ export const htmlToSlate = (html: string) => {
     } else {
       // Parsing completed, do something
       slateContent = dom
-        .map((node) => deserialize(node)) // run the deserializer
+        .map((node) => deserialize(node, { attributeMap })) // run the deserializer
         .filter((element) => element) // filter out null elements
         .map((element) => {
           // ensure all top level elements have a children property

--- a/src/serializers/slatetoHtml/index.ts
+++ b/src/serializers/slatetoHtml/index.ts
@@ -2,6 +2,11 @@ import { escape } from 'html-escaper'
 import { Text } from 'slate'
 import { prependSpace } from '../../utilities'
 
+interface IpropertyMap {
+  slateAttr: string
+  htmlAttr: string
+}
+
 export const slateToHtml = (
   node: any[],
   {
@@ -9,7 +14,7 @@ export const slateToHtml = (
     attributePropertyMap = []
   }: {
     enforceTopLevelPTags?: boolean,
-    attributePropertyMap?: any[]
+    attributePropertyMap?: IpropertyMap[]
   } = {},
 ) => {
   const nodeWithTopLevelPElements = node.map((el) => {

--- a/src/serializers/slatetoHtml/index.ts
+++ b/src/serializers/slatetoHtml/index.ts
@@ -3,12 +3,13 @@ import { Text } from 'slate'
 
 export const slateToHtml = (
   node: any[],
-  options = {
-    enforceTopLevelPTags: false,
-  },
+  {
+    enforceTopLevelPTags =false,
+    attributePropertyMap = []
+  } = {},
 ) => {
   const nodeWithTopLevelPElements = node.map((el) => {
-    if (!el.type && options?.enforceTopLevelPTags) {
+    if (!el.type && enforceTopLevelPTags) {
       return {
         ...el,
         type: 'p',

--- a/src/serializers/slatetoHtml/index.ts
+++ b/src/serializers/slatetoHtml/index.ts
@@ -7,9 +7,9 @@ export const slateToHtml = (
   node: any[],
   {
     enforceTopLevelPTags = false,
-    attributeMap = []
+    attributeMap = [],
   }: {
-    enforceTopLevelPTags?: boolean,
+    enforceTopLevelPTags?: boolean
     attributeMap?: IattributeMap[]
   } = {},
 ) => {
@@ -26,11 +26,14 @@ export const slateToHtml = (
   return slateNodeToHtml(slateNode, { attributeMap })
 }
 
-const slateNodeToHtml = (node: any, {
-  attributeMap = []
-}: {
-  attributeMap?: IattributeMap[]
-} = {}) => {
+const slateNodeToHtml = (
+  node: any,
+  {
+    attributeMap = [],
+  }: {
+    attributeMap?: IattributeMap[]
+  } = {},
+) => {
   if (Text.isText(node)) {
     let str = escape(node.text)
     if ((node as any).code) {
@@ -51,15 +54,18 @@ const slateNodeToHtml = (node: any, {
     return str
   }
 
-  const children: any[] = node.children ? node.children.map((n: any[]) => slateNodeToHtml(n, { attributeMap })).join('') : []
+  const children: any[] = node.children
+    ? node.children.map((n: any[]) => slateNodeToHtml(n, { attributeMap })).join('')
+    : []
 
-  let attrs = attributeMap.map(map => {
-    if (node[map.slateAttr]) {
-      return `${map.htmlAttr}="${node[map.slateAttr]}"`
-    }
-    return null
-  })
-  .filter(map => map)
+  let attrs = attributeMap
+    .map((map) => {
+      if (node[map.slateAttr]) {
+        return `${map.htmlAttr}="${node[map.slateAttr]}"`
+      }
+      return null
+    })
+    .filter((map) => map)
 
   switch (node.type) {
     case 'p':

--- a/src/serializers/slatetoHtml/index.ts
+++ b/src/serializers/slatetoHtml/index.ts
@@ -1,20 +1,16 @@
 import { escape } from 'html-escaper'
 import { Text } from 'slate'
 import { prependSpace } from '../../utilities'
-
-interface IpropertyMap {
-  slateAttr: string
-  htmlAttr: string
-}
+import { IattributeMap } from '../../types'
 
 export const slateToHtml = (
   node: any[],
   {
     enforceTopLevelPTags = false,
-    attributePropertyMap = []
+    attributeMap = []
   }: {
     enforceTopLevelPTags?: boolean,
-    attributePropertyMap?: IpropertyMap[]
+    attributeMap?: IattributeMap[]
   } = {},
 ) => {
   const nodeWithTopLevelPElements = node.map((el) => {
@@ -27,13 +23,13 @@ export const slateToHtml = (
     return el
   })
   const slateNode = { children: nodeWithTopLevelPElements }
-  return slateNodeToHtml(slateNode, { attributePropertyMap })
+  return slateNodeToHtml(slateNode, { attributeMap })
 }
 
 const slateNodeToHtml = (node: any, {
-  attributePropertyMap = []
+  attributeMap = []
 }: {
-  attributePropertyMap?: any[]
+  attributeMap?: IattributeMap[]
 } = {}) => {
   if (Text.isText(node)) {
     let str = escape(node.text)
@@ -55,9 +51,9 @@ const slateNodeToHtml = (node: any, {
     return str
   }
 
-  const children: any[] = node.children ? node.children.map((n: any[]) => slateNodeToHtml(n, { attributePropertyMap })).join('') : []
+  const children: any[] = node.children ? node.children.map((n: any[]) => slateNodeToHtml(n, { attributeMap })).join('') : []
 
-  let attrs = attributePropertyMap.map(map => {
+  let attrs = attributeMap.map(map => {
     if (node[map.slateAttr]) {
       return `${map.htmlAttr}="${node[map.slateAttr]}"`
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export interface IattributeMap {
+  slateAttr: string
+  htmlAttr: string
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,1 +1,3 @@
 export const hasLineBreak = (str: string) => str.match(/[\r\n]+/) !== null
+
+export const prependSpace = (str: string) => str && ` ${str.trim()}`


### PR DESCRIPTION
Support custom attribute mapping. Attributes in Slate can be mapped to HTML attributes and vice versa.

In the case of Payload CMS, this is a useful feature: we can preserve the `linkType` field which determines whether a link is `custom` (manually defined) or internal (links to a document in the CMS).