### PR TITLE
refactor(slatetohtml): convert to dom instead of html strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.8](https://github.com/thompsonsj/slate-serializers/compare/v0.0.7...v0.0.8) (2022-11-25)
+
+
+### Features
+
+* **htmltoslate:** support line breaks ([#6](https://github.com/thompsonsj/slate-serializers/issues/6)) ([fe98bfb](https://github.com/thompsonsj/slate-serializers/commit/fe98bfbc24bd4ff9025f70b08f16f8994ac9247f))
+* **slatetohtml:** support newtab links ([#5](https://github.com/thompsonsj/slate-serializers/issues/5)) ([ef8d004](https://github.com/thompsonsj/slate-serializers/commit/ef8d004a101f69e7999c59dab4f5f68b3dd5435d))
+* support custom attributes ([#7](https://github.com/thompsonsj/slate-serializers/issues/7)) ([2192b0e](https://github.com/thompsonsj/slate-serializers/commit/2192b0ea5c972d12901ac2ebfc4e35120408f46e))
+
 ### [0.0.7](https://github.com/thompsonsj/slate-serializers/compare/v0.0.5...v0.0.7) (2022-11-25)
 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A collection of serializers to convert [Slate](https://www.npmjs.com/package/sla
 
 Serializers included so far:
 
+- `slateToDom`
 - `slateToHtml`
 - `htmlToSlate`
 
@@ -98,6 +99,12 @@ const slateReserialized = htmlToSlate(html,
 
 ## Details
 
+### slateToDom
+
+`slateToHtml` is a simple wrapper that runs [`dom-serializer`](https://www.npmjs.com/package/dom-serializer) on the output from `slateToDom`.
+
+`slateToDom` is made available in case you wish to work woth the DOM output yourself or run `dom-serializer` using any of the available options.
+
 ### slateToHtml
 
 Based on logic in [Deserializing | Serializing | Slate](https://docs.slatejs.org/concepts/10-serializing#deserializing).
@@ -107,18 +114,6 @@ Based on logic in [Deserializing | Serializing | Slate](https://docs.slatejs.org
 - Works in all environments, including Node.js.
 - Speed - `htmlparser2` is the fastest HTML parser.
 - Forgiving regarding HTML spec compliance.
-
-#### Options
-
-You may get better results passing the `enforceTopLevelPTags` option.
-
-```js
-slateToHtml(slate, {enforceTopLevelPTags: true})
-```
-
-Objects in the Slate JSON can have no type (e.g. `p`) and contain a number of children. This causes issues for the serializer, which renders each child at the top of the DOM. Example: `Paragraph 1.Paragraph 2.`. Complexity is increased when text marks are involved such as `u`, `strong` and `i`.
-
-To avoid this, `enforceTopLevelPTags` ensures any top level objects without a type are assigned as a `p` tag. Example: `<p>Paragraph 1.</p><p>Paragraph 2.</p>`.
 
 ### htmlToSlate
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.8",
       "license": "ISC",
       "dependencies": {
+        "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
         "html-escaper": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slate-serializers",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slate-serializers",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "ISC",
       "dependencies": {
         "domhandler": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slate-serializers",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Serialize Slate JSON objects to HTML and vice versa. Define rules to modify the end result.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     ]
   },
   "dependencies": {
+    "dom-serializer": "^2.0.0",
     "domhandler": "^5.0.3",
     "domutils": "^3.0.1",
     "html-escaper": "^3.0.3",

--- a/src/__tests__/combined.spec.ts
+++ b/src/__tests__/combined.spec.ts
@@ -40,7 +40,7 @@ describe('attribute mapping', () => {
     },
   ]
   const html =
-    '<p>Some text before an inline link <a href="https://github.com/thompsonsj/slate-serializers" target="_blank" data-link-type="custom">slate-serializers | GitHub</a>.</p>'
+    '<p>Some text before an inline link <a href="https://github.com/thompsonsj/slate-serializers" data-link-type="custom" target="_blank">slate-serializers | GitHub</a>.</p>'
 
   it('slateToHtml adds a custom data attribute', () => {
     expect(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { htmlToSlate } from './serializers/htmlToSlate'
-export { slateToHtml } from './serializers/slatetoHtml'
+export { slateToDom, slateToHtml } from './serializers/slatetoHtml'

--- a/src/serializers/slatetoHtml/index.ts
+++ b/src/serializers/slatetoHtml/index.ts
@@ -36,6 +36,20 @@ export const slateToHtml = (
     attributeMap?: IattributeMap[]
   } = {},
 ) => {
+  const document = slateToDom(node, { attributeMap, enforceTopLevelPTags })
+  return serializer(document)
+}
+
+export const slateToDom = (
+  node: any[],
+  {
+    enforceTopLevelPTags = false,
+    attributeMap = [],
+  }: {
+    enforceTopLevelPTags?: boolean
+    attributeMap?: IattributeMap[]
+  } = {},
+) => {
   const nodeWithTopLevelPElements = node.map((el) => {
     if (!el.type && enforceTopLevelPTags) {
       return {
@@ -47,7 +61,7 @@ export const slateToHtml = (
   })
   const slateNode = { children: nodeWithTopLevelPElements }
   const document = slateNodeToHtml(slateNode, { attributeMap })
-  return serializer(document)
+  return document
 }
 
 const slateNodeToHtml = (

--- a/src/serializers/slatetoHtml/index.ts
+++ b/src/serializers/slatetoHtml/index.ts
@@ -1,7 +1,30 @@
 import { escape } from 'html-escaper'
 import { Text } from 'slate'
-import { prependSpace } from '../../utilities'
+import { Document, Element} from 'domhandler'
 import { IattributeMap } from '../../types'
+import { nestedMarkElements } from '../../utilities/domhandler'
+import serializer from 'dom-serializer'
+
+interface stringKeyObject {
+  [name: string]: string;
+}
+
+// Map Slate element names to HTML tag names
+// Only to be used for standard 'wrapper' elements
+const ELEMENT_NAME_TAG_MAP = new Map([
+  ['p', 'p'],
+  ['paragraph', 'p'],
+  ['h1', 'h1'],
+  ['h2', 'h2'],
+  ['h3', 'h3'],
+  ['h4', 'h4'],
+  ['h5', 'h5'],
+  ['h6', 'h6'],
+  ['ul', 'ul'],
+  ['ol', 'ol'],
+  ['li', 'li'],
+  ['blockquote', 'blockquote']
+])
 
 export const slateToHtml = (
   node: any[],
@@ -23,7 +46,8 @@ export const slateToHtml = (
     return el
   })
   const slateNode = { children: nodeWithTopLevelPElements }
-  return slateNodeToHtml(slateNode, { attributeMap })
+  const document = slateNodeToHtml(slateNode, { attributeMap })
+  return serializer(document)
 }
 
 const slateNodeToHtml = (
@@ -36,71 +60,65 @@ const slateNodeToHtml = (
 ) => {
   if (Text.isText(node)) {
     let str = escape(node.text)
-    if ((node as any).code) {
-      str = `<pre><code>${str}</code></pre>`
-    }
-    if ((node as any).italic) {
-      str = `<i>${str}</i>`
-    }
-    if ((node as any).underline) {
-      str = `<u>${str}</u>`
+    let markElements = []
+    if ((node as any).strikethrough) {
+      markElements.push('s')
     }
     if ((node as any).bold) {
-      str = `<strong>${str}</strong>`
+      markElements.push('strong')
     }
-    if ((node as any).strikethrough) {
-      str = `<s>${str}</s>`
+    if ((node as any).underline) {
+      markElements.push('u')
     }
-    return str
+    if ((node as any).italic) {
+      markElements.push('i')
+    }
+    if ((node as any).code) {
+      markElements.push('pre', 'code')
+    }
+    return nestedMarkElements(markElements, str)
   }
 
   const children: any[] = node.children
-    ? node.children.map((n: any[]) => slateNodeToHtml(n, { attributeMap })).join('')
+    ? node.children.map((n: any[]) => slateNodeToHtml(n, { attributeMap }))
     : []
 
-  let attrs = attributeMap
-    .map((map) => {
+  let attrs: stringKeyObject = {}
+  // tslint:disable-next-line no-unused-expression
+  attributeMap
+    .forEach((map) => {
       if (node[map.slateAttr]) {
-        return `${map.htmlAttr}="${node[map.slateAttr]}"`
+        attrs[map.htmlAttr] = node[map.slateAttr]
       }
-      return null
     })
-    .filter((map) => map)
+
+  if (ELEMENT_NAME_TAG_MAP.has(node.type)) {
+    return new Element(
+      ELEMENT_NAME_TAG_MAP.get(node.type) || '',
+      attrs,
+      children
+    )
+  }
 
   switch (node.type) {
-    case 'p':
-      return `<p${prependSpace(attrs.join(' '))}>${children}</p>`
-    case 'h1':
-      return `<h1${prependSpace(attrs.join(' '))}>${children}</h1>`
-    case 'h2':
-      return `<h2${prependSpace(attrs.join(' '))}>${children}</h2>`
-    case 'h3':
-      return `<h3${prependSpace(attrs.join(' '))}>${children}</h3>`
-    case 'h4':
-      return `<h4${prependSpace(attrs.join(' '))}>${children}</h4>`
-    case 'h5':
-      return `<h5${prependSpace(attrs.join(' '))}>${children}</h5>`
-    case 'h6':
-      return `<h6${prependSpace(attrs.join(' '))}>${children}</h6>`
     case 'quote':
-      return `<blockquote${prependSpace(attrs.join(' '))}><p>${children}</p></blockquote>`
-    case 'paragraph':
-      return `<p${prependSpace(attrs.join(' '))}>${children}</p>`
-    case 'ul':
-      return `<ul${prependSpace(attrs.join(' '))}>${children}</ul>`
-    case 'ol':
-      return `<ol${prependSpace(attrs.join(' '))}>${children}</ol>`
-    case 'li':
-      return `<li${prependSpace(attrs.join(' '))}>${children}</li>`
+      const p = [new Element('p', {}, children)]
+      return new Element(
+        'blockquote',
+        attrs,
+        p
+      )
     case 'link':
-      const newTabAttr = node.newTab ? 'target="_blank"' : ''
-      if (newTabAttr) {
-        attrs = [newTabAttr, ...attrs]
-      }
-      return `<a href="${escape(node.url)}"${prependSpace(attrs.join(' '))}>${children}</a>`
-    case 'blockquote':
-      return `<blockquote${prependSpace(attrs.join(' '))}>${children}</blockquote>`
+      if (node.newTab) { attrs.target = "_blank"}
+      return new Element(
+        'a',
+        {
+          href: escape(node.url),
+          ...attrs,
+        },
+        children
+      )
     default:
-      return children
+      return new Document(children)
   }
 }

--- a/src/utilities/domhandler.spec.ts
+++ b/src/utilities/domhandler.spec.ts
@@ -1,0 +1,23 @@
+import { nestedMarkElementsString } from "./domhandler"
+
+/**
+ * Helper functions for domhandler
+ */
+
+describe('nestedMarkElementsString', () => {
+  it('nests text in 1 mark element', () => {
+    expect(nestedMarkElementsString(['u'], 'Unarticulated Annotation text')).toEqual("<u>Unarticulated Annotation text</u>")
+  })
+
+  it('nests text in 2 mark elements', () => {
+    expect(nestedMarkElementsString(['u', 'i'], 'Unarticulated Annotation, and Idiomatic Text text')).toEqual("<u><i>Unarticulated Annotation, and Idiomatic Text text</i></u>")
+  })
+
+  it('nests text in 3 mark elements', () => {
+    expect(nestedMarkElementsString(['u', 'i', 'strong'], 'Strong Importance, Unarticulated Annotation, and Idiomatic Text text')).toEqual("<u><i><strong>Strong Importance, Unarticulated Annotation, and Idiomatic Text text</strong></i></u>")
+  })
+
+  it('nests text in 4 mark elements', () => {
+    expect(nestedMarkElementsString(['u', 'i', 'strong', 's'], 'Strong Importance, Unarticulated Annotation, Idiomatic Text and Strikethrough text')).toEqual("<u><i><strong><s>Strong Importance, Unarticulated Annotation, Idiomatic Text and Strikethrough text</s></strong></i></u>")
+  })
+})

--- a/src/utilities/domhandler.ts
+++ b/src/utilities/domhandler.ts
@@ -1,0 +1,47 @@
+import { Element, Text } from 'domhandler'
+import serializer from 'dom-serializer'
+
+/**
+ * Generate nested mark elements
+ * 
+ * nestedMarkElements should be recursive, but it works
+ * so leaving it for now. Can handle a maximum of 5
+ * elements. Really shouldn't be any more than that!
+ */
+
+export const nestedMarkElementsString = (els: string[], text: string) => {
+  return serializer(nestedMarkElements(els, text))
+}
+
+export const nestedMarkElements = (els: string[], text: string) => {
+  if (els.length === 0) {
+    return new Text(text)
+  }
+  let element
+  const el1 = els.pop()
+  element = new Element(el1 as string, {}, [new Text(text)])
+  if (!els || els.length === 0) {
+    return element
+  }
+  const el2 = els.pop()
+  element = new Element(el2 as string, {}, [element])
+  if (!els || els.length === 0) {
+    return element
+  }
+  const el3 = els.pop()
+  element = new Element(el3 as string, {}, [element])
+  if (!els || els.length === 0) {
+    return element
+  }
+  const el4 = els.pop()
+  element = new Element(el4 as string, {}, [element])
+  if (!els || els.length === 0) {
+    return element
+  }
+  const el5 = els.pop()
+  element = new Element(el5 as string, {}, [element])
+  if (!els || els.length === 0) {
+    return element
+  }
+  return element
+}


### PR DESCRIPTION
Convert Slate JSON to a DOM first, then serialize to a string using [`dom-serializer`](https://www.npmjs.com/package/dom-serializer).

## Details

Considering that `htmlparser2` and its associated utilities are being used for `htmlToSlate`, it makes sense that these powerful utilities are also used the other way round.

The Slate to HTML serializer is based on https://docs.slatejs.org/concepts/10-serializing#html, but it's time to move away from writing strings directly. The code becomes much easier to work with when building a DOM document from the Slate JSON, and then using [dom-serializer](https://www.npmjs.com/package/dom-serializer) to write out a string.

Rationale:

- **Cleaner logic**. Avoid writing utilities/functionality for writing HTML strings - e.g. `<p${prependSpace(attrs.join(' '))}>${children}</p>` was already messy, and would have benefited from refactoring. But this is already well-considered in `dom-serializer`.
- **More flexibility** in how the HTML is serialized. See options in https://www.npmjs.com/package/dom-serializer.
- **Better typing**. This approach gives better typing because `domhandler` objects are being created instead of strings.
- **Enforce HTML rules/standards**. Creating a DOM first inherently means the end result is more likely to be valid HTML. 