### PR TITLE
feat(defaulttag): replace enforceTopLevelPTags

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ const serializedToHtml = slateToHtml(slate, payloadSlateToDomConfig)
 
 You can create your own configuration file that implements your schema. See [src/config/slatetoDom/payload.ts](src/config/slatetoDom/payload.ts) for an example of how to extend the default configuration or copy [src/config/slatetoDom/default.ts](src/config/slatetoDom/default.ts) and rewrite it as appropriate.
 
+Note the `defaultTag` option that is passed in the Payload CMS configuration. This creates a `<p>` HTML element tag whenever a Slate node has an undefined `type`. See https://github.com/payloadcms/payload/discussions/1141#discussioncomment-4255845.
+
 #### Implementation details
 
 Based on logic in [Deserializing | Serializing | Slate](https://docs.slatejs.org/concepts/10-serializing#deserializing).

--- a/src/__tests__/combined.spec.ts
+++ b/src/__tests__/combined.spec.ts
@@ -10,7 +10,7 @@ describe('HTML to Slate JSON transforms', () => {
     const fixtures = combinedFixtures
     for (const fixture of fixtures) {
       it(`${fixture.name}`, () => {
-        expect(slateToHtml(fixture.slateOriginal, { ...slateToDomConfig, enforceTopLevelPTags: true })).toEqual(
+        expect(slateToHtml(fixture.slateOriginal, { ...slateToDomConfig, defaultTag: 'p' })).toEqual(
           fixture.html,
         )
         expect(htmlToSlate(fixture.html)).toEqual(fixture.slateReserialized)

--- a/src/config/slatetoDom/default.ts
+++ b/src/config/slatetoDom/default.ts
@@ -8,7 +8,7 @@ export interface Config {
   markMap: { [key: string]: string[] }
   elementMap: { [key: string]: string }
   elementTransforms: ElementTagTransform
-  enforceTopLevelPTags?: boolean
+  defaultTag?: string
 }
 
 // Map Slate element names to HTML tag names
@@ -60,5 +60,4 @@ export const config: Config = {
       )
     },
   },
-  enforceTopLevelPTags: false,
 }

--- a/src/config/slatetoDom/payload.ts
+++ b/src/config/slatetoDom/payload.ts
@@ -29,4 +29,5 @@ export const config: Config = {
       )
     },
   },
+  defaultTag: 'p'
 }

--- a/src/serializers/slatetoHtml/index.ts
+++ b/src/serializers/slatetoHtml/index.ts
@@ -14,17 +14,7 @@ export const slateToHtml: SlateToHtml = (node: any[], config = defaultConfig) =>
 }
 
 export const slateToDom: SlateToDom = (node: any[], config = defaultConfig) => {
-  const nodeWithTopLevelPElements = node.map((el) => {
-    if (!el.type && config.enforceTopLevelPTags) {
-      return {
-        ...el,
-        type: 'p',
-      }
-    }
-    return el
-  })
-  const slateNode = { children: nodeWithTopLevelPElements }
-  const document = slateNodeToHtml(slateNode, config)
+  const document = node.map(n => slateNodeToHtml(n, config))
   return document
 }
 
@@ -52,5 +42,8 @@ const slateNodeToHtml = (node: any, config = defaultConfig) => {
     return config.elementTransforms[node.type](node, children)
   }
 
+  if (config.defaultTag && !node.type) {
+    return new Element(config.defaultTag, {}, children)
+  }
   return new Document(children)
 }


### PR DESCRIPTION
Replace the `enforceTopLevelPTags` option with a more general and useful `defaultTag` option, which will create a HTML element as defined for any Slate nodes with undefined types.

## Details

`enforceTopLevelPTags` never really made sense. Nor did the mistake I made in inadvertently creating an extra top level node that contained all the Slate nodes passed to the parser.

This resolves the situation by replacing `enforceTopLevelPTags` with a `defaultTag` option that can accept a string used to create any HTML element. For the Payload CMS configuration, this is used to create a `<p>` HTML element for any Slate node with an undefined `type`.

This is based on investigations that led to the following comment: https://github.com/payloadcms/payload/discussions/1141#discussioncomment-4255845. 