### PR TITLE
fix(slatetohtml): do not escape encoded HTML special characters

### DIFF
--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -1,4 +1,4 @@
-import { htmlToSlate } from '../../../src/serializers/htmlToSlate'
+import { htmlToSlate } from '../../../src'
 
 describe('htmlToSlate expected behaviour', () => {
   it('ignores non-HTML line breaks and extra spaces', () => {

--- a/__tests__/serializers/slateToHtml/index.spec.ts
+++ b/__tests__/serializers/slateToHtml/index.spec.ts
@@ -1,0 +1,18 @@
+import { slateToHtml } from "../../../src"
+
+describe('slateToHtml expected behaviour', () => {
+  it('encodes HTML entities', () => {
+    const html = `<h1>What&apos;s Heading 1</h1>`
+    const slate = [
+      {
+        children: [
+          {
+            text: "What's Heading 1",
+          },
+        ],
+        type: 'h1',
+      },
+    ]
+    expect(slateToHtml(slate)).toEqual(html)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "html-escaper": "^3.0.3",
         "htmlparser2": "^8.0.1",
         "slate": "^0.86.0",
         "slate-hyperscript": "^0.77.0"
@@ -4152,11 +4151,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/html-escaper": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
     },
     "node_modules/htmlparser2": {
       "version": "8.0.1",
@@ -11761,11 +11755,6 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
-    },
-    "html-escaper": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
     },
     "htmlparser2": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "dom-serializer": "^2.0.0",
     "domhandler": "^5.0.3",
     "domutils": "^3.0.1",
-    "html-escaper": "^3.0.3",
     "htmlparser2": "^8.0.1",
     "slate": "^0.86.0",
     "slate-hyperscript": "^0.77.0"

--- a/src/serializers/slatetoHtml/index.ts
+++ b/src/serializers/slatetoHtml/index.ts
@@ -1,4 +1,3 @@
-import { escape } from 'html-escaper'
 import { Text } from 'slate'
 import { AnyNode, Document, Element } from 'domhandler'
 import { nestedMarkElements } from '../../utilities/domhandler'
@@ -20,7 +19,7 @@ export const slateToDom: SlateToDom = (node: any[], config = defaultConfig) => {
 
 const slateNodeToHtml = (node: any, config = defaultConfig) => {
   if (Text.isText(node)) {
-    const str = escape(node.text)
+    const str = node.text
     const markElements: string[] = []
     Object.keys(config.markMap).forEach((key) => {
       if ((node as any)[key]) {


### PR DESCRIPTION
Fix double encoding of HTML special characters.

## Details

https://github.com/thompsonsj/slate-serializers/pull/9 introduced serializing to a DOM rather than trying to write our own HTML using strings.

Since this change, encoding rules for HTML entities/special characters is automatically handled by [`htmlparser2`](https://github.com/fb55/htmlparser2) and associated utilities, based on what type of node they are rendering (e.g. a text node or an element).

This removes the need for the [`html-escaper`](https://www.npmjs.com/package/html-escaper) dependency. Use of it, and the dependency itself is removed. This avoids issues that were arising such as:

`I'm` in a Slate JSON `text` property being rendered as `I&amp;m` in HTML.