### PR TITLE
feat(slatetohtml): control html entity encoding

### DIFF
--- a/__tests__/serializers/slateToHtml/index.spec.ts
+++ b/__tests__/serializers/slateToHtml/index.spec.ts
@@ -1,4 +1,4 @@
-import { slateToHtml } from "../../../src"
+import { slateToHtml, slateToDomConfig } from "../../../src"
 
 describe('slateToHtml expected behaviour', () => {
   it('encodes HTML entities', () => {
@@ -14,5 +14,20 @@ describe('slateToHtml expected behaviour', () => {
       },
     ]
     expect(slateToHtml(slate)).toEqual(html)
+  })
+
+  it('does not encode HTML entities with the appropriate option', () => {
+    const html = `<h1>What's Heading 1</h1>`
+    const slate = [
+      {
+        children: [
+          {
+            text: "What's Heading 1",
+          },
+        ],
+        type: 'h1',
+      },
+    ]
+    expect(slateToHtml(slate, { ...slateToDomConfig, encodeEntities: false })).toEqual(html)
   })
 })

--- a/src/config/slatetoDom/default.ts
+++ b/src/config/slatetoDom/default.ts
@@ -9,6 +9,7 @@ export interface Config {
   elementMap: { [key: string]: string }
   elementTransforms: ElementTagTransform
   defaultTag?: string
+  encodeEntities?: boolean
 }
 
 // Map Slate element names to HTML tag names
@@ -60,4 +61,5 @@ export const config: Config = {
       )
     },
   },
+  encodeEntities: true,
 }

--- a/src/serializers/slatetoHtml/index.ts
+++ b/src/serializers/slatetoHtml/index.ts
@@ -9,7 +9,9 @@ type SlateToDom = (node: any[], config?: Config) => AnyNode | ArrayLike<AnyNode>
 
 export const slateToHtml: SlateToHtml = (node: any[], config = defaultConfig) => {
   const document = slateToDom(node, config)
-  return serializer(document)
+  return serializer(document, {
+    encodeEntities: 'encodeEntities' in config ? config.encodeEntities : false
+  })
 }
 
 export const slateToDom: SlateToDom = (node: any[], config = defaultConfig) => {


### PR DESCRIPTION
Add on option to control whether or not HTML entities are encoded.

## Details

`slateToHtml` encodes HTML entities by default. This the default behaviour of [`dom-serializer`](https://www.npmjs.com/package/dom-serializer).

It's a sensible default, and it is likely what we want when rendering HTML.

However, in some use cases, it makes sense to disable HTML entity encoding. For example, CrowdIn displays them as special characters when localizing a HTML document. When sending HTML to CrowdIn and reserializing content back to Slate JSON, it makes sense to disable entities for easier reading, editing and localization.