### PR TITLE
feat(htmltoslate): process whitespace depending on context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ dist
 # End of https://mrkandreev.name/snippets/gitignore-generator/#Node
 
 /lib
+/temp

--- a/README.md
+++ b/README.md
@@ -135,11 +135,15 @@ const serializedToSlate = htmlToSlate(html, payloadHtmlToSlateConfig)
 
 You can create your own configuration file that implements your schema. See [src/config/htmlToSlate/payload.ts](src/config/htmlToSlate/payload.ts) for an example of how to extend the default configuration or copy [src/config/htmlToSlate/default.ts](src/config/htmlToSlate/default.ts) and rewrite it as appropriate.
 
+#### Whitespace
+
+`htmlToSlate` processes whitespace in a similar way to browsers. It minifies whitespace while trying to preserve meaning. For details, see [docs/engineering.md#whitespace](docs/engineering.md#whitespace).
+
 ### slateToDom
 
 `slateToHtml` is a simple wrapper that runs [`dom-serializer`](https://www.npmjs.com/package/dom-serializer) on the output from `slateToDom`.
 
-`slateToDom` is made available in case you wish to work woth the DOM output yourself or run `dom-serializer` using any of the available options.
+`slateToDom` is made available in case you wish to work with the DOM output yourself or run `dom-serializer` using any of the available options.
 
 It accepts the same configuration object as [slateToHtml](#slatetohtml).
 

--- a/__tests__/serializers/combined/fixtures/combined.ts
+++ b/__tests__/serializers/combined/fixtures/combined.ts
@@ -79,15 +79,9 @@ export const fixtures: Ifixture[] = [
       },
     ],
   },
-  /**
-   * this is an interesting test - note the line break
-   * included by Slate. We need to support this in
-   * reserialized Slate in order to get matching HTML
-   *  */
   {
     name: 'links nested in an unordered list',
-    html: `<ul><li><a href="https://github.com/thompsonsj/slate-serializers" target="_blank">slate-serializers | GitHub</a></li><li><a href="https://github.com/thompsonsj/slate-serializers" target="_blank">slate-serializers | GitHub</a>
-</li></ul>`,
+    html: `<ul><li><a href="https://github.com/thompsonsj/slate-serializers" target="_blank">slate-serializers | GitHub</a></li><li><a href="https://github.com/thompsonsj/slate-serializers" target="_blank">slate-serializers | GitHub</a></li></ul>`,
     slateOriginal: [
       {
         type: 'ul',
@@ -130,9 +124,6 @@ export const fixtures: Ifixture[] = [
                     text: 'slate-serializers | GitHub',
                   },
                 ],
-              },
-              {
-                text: '\n',
               },
             ],
           },
@@ -181,9 +172,6 @@ export const fixtures: Ifixture[] = [
                     text: 'slate-serializers | GitHub',
                   },
                 ],
-              },
-              {
-                text: '\n',
               },
             ],
           },

--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -1,4 +1,4 @@
-import { htmlToSlate, htmlToSlateConfig } from '../../../src'
+import { htmlToSlate, htmlToSlateConfig, payloadHtmlToSlateConfig } from '../../../src'
 
 describe('htmlToSlate whitespace handling', () => {
   describe('inline formatting context', () => {
@@ -28,9 +28,6 @@ describe('htmlToSlate whitespace handling', () => {
                  ],
                  type: "span",
                },
-               {
-                "text": "",
-              },
             ],
             "type": "h1",
           },
@@ -55,13 +52,6 @@ describe('htmlToSlate whitespace handling', () => {
 `
       const expected: any[] = [
         {
-            children: [
-            {
-                text: " ",
-              },
-            ],
-          },
-        {
           children: [
           {
               text: "Hello",
@@ -69,13 +59,6 @@ describe('htmlToSlate whitespace handling', () => {
           ],
           type: "div",
         },
-        {
-            children: [
-            {
-                text: ` `,
-              },
-            ],
-          },
         {
           children: [
           {
@@ -146,6 +129,27 @@ describe('htmlToSlate whitespace handling', () => {
         },
       ]
       expect(htmlToSlate(fixture)).toEqual(expected)
+    })
+
+    it('removes non-mapped block elements containing whitespace only', () => {
+      const fixture = "<div>Für Ihre Sicherheit&nbsp;</div>\n<div>&nbsp;</div>\n<div>Bitte beachten Sie die Ansagen der Besatzung</div>"
+      const expected: any[] = [
+        {
+          children: [
+            {
+              text: "Für Ihre Sicherheit",
+            },
+          ],
+        },
+        {
+          children: [
+            {
+              text: "Bitte beachten Sie die Ansagen der Besatzung",
+            },
+          ],
+        },
+      ]
+      expect(htmlToSlate(fixture, payloadHtmlToSlateConfig)).toEqual(expected)
     })
   })
 })

--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -132,12 +132,40 @@ describe('htmlToSlate whitespace handling', () => {
     })
 
     it('removes non-mapped block elements containing whitespace only', () => {
+      const fixture = "<div>Für Ihre Sicherheit&nbsp;</div>\n<div>  </div>\n<div>Bitte beachten Sie die Ansagen der Besatzung</div>"
+      const expected: any[] = [
+        {
+          children: [
+            {
+              text: "Für Ihre Sicherheit&nbsp;",
+            },
+          ],
+        },
+        {
+          children: [
+            {
+              text: "Bitte beachten Sie die Ansagen der Besatzung",
+            },
+          ],
+        },
+      ]
+      expect(htmlToSlate(fixture, payloadHtmlToSlateConfig)).toEqual(expected)
+    })
+
+    it('does not remove non-mapped block elements with text contents consisting of a non-breaking line space', () => {
       const fixture = "<div>Für Ihre Sicherheit&nbsp;</div>\n<div>&nbsp;</div>\n<div>Bitte beachten Sie die Ansagen der Besatzung</div>"
       const expected: any[] = [
         {
           children: [
             {
-              text: "Für Ihre Sicherheit",
+              text: "Für Ihre Sicherheit&nbsp;",
+            },
+          ],
+        },
+        {
+          children: [
+            {
+              text: "&nbsp;",
             },
           ],
         },

--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -18,8 +18,7 @@ describe('htmlToSlate whitespace handling', () => {
         {
           children: [
             {
-              text: `   Hello 
-        `,
+              text: `Hello `,
             },
         {
                 children: [
@@ -30,7 +29,7 @@ describe('htmlToSlate whitespace handling', () => {
                  type: "span",
                },
                {
-                "text": "   ",
+                "text": "",
               },
             ],
             "type": "h1",
@@ -58,40 +57,37 @@ describe('htmlToSlate whitespace handling', () => {
         {
             children: [
             {
-                text: "  ",
+                text: " ",
               },
             ],
           },
         {
-            children: [
-            {
-                text: "  Hello  ",
-              },
-            ],
-            type: "div",
-          },
+          children: [
+          {
+              text: "Hello",
+            },
+          ],
+          type: "div",
+        },
         {
             children: [
             {
-                text: `
-
-    `,
+                text: ` `,
               },
             ],
           },
         {
-            children: [
-            {
-                text: "  World!   ",
-              },
-            ],
-            type: "div",
-          },
+          children: [
+          {
+              text: "World!",
+            },
+          ],
+          type: "div",
+        },
         {
             children: [
             {
-                text: ` . 
-`,
+                text: ` . `,
               },
             ],
           },

--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -1,51 +1,155 @@
-import { htmlToSlate } from '../../../src'
+import { htmlToSlate, htmlToSlateConfig } from '../../../src'
 
-describe('htmlToSlate expected behaviour', () => {
-  it('ignores non-HTML line breaks and extra spaces', () => {
-    const fixture = `<h1>Heading 1</h1>
-    <p>Paragraph 1</p>`
-    const expected = [
-      {
-        children: [
-          {
-            text: 'Heading 1',
+describe('htmlToSlate whitespace handling', () => {
+  describe('inline formatting context', () => {
+
+    /**
+     * inline formatting example from mdn web docs
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace
+     * 
+     * <h1>◦◦◦Hello◦⏎
+     * ⇥⇥⇥⇥<span>◦World!</span>⇥◦◦</h1>
+     */
+    it ('processes the hello world example in the same way as mdn docs', () => {
+      const fixture = `<h1>   Hello 
+        <span> World!</span>   </h1>`
+      const expected: any[] = [
+        {
+          children: [
+            {
+              text: `   Hello 
+        `,
+            },
+        {
+                children: [
+                  {
+                     text: " World!",
+                   },
+                 ],
+                 type: "span",
+               },
+               {
+                "text": "   ",
+              },
+            ],
+            "type": "h1",
           },
-        ],
-        type: 'h1',
-      },
-      {
-        children: [
-          {
-            text: '\n    ',
+        ]
+      // extend the config to handle span tags
+      const config = {
+        ...htmlToSlateConfig,
+        elementTags: {
+          ...htmlToSlateConfig.elementTags,
+          span: () => ({ type: 'span' })
+        }
+      }
+      expect(htmlToSlate(fixture, config)).toEqual(expected)
+    })
+  })
+  
+  describe('block formatting context', () => {
+    it('processes the hello world example in the same way as mdn docs', () => {
+      const fixture = `  <div>  Hello  </div>
+
+    <div>  World!   </div> . 
+`
+      const expected: any[] = [
+        {
+            children: [
+            {
+                text: "  ",
+              },
+            ],
           },
-        ],
-      },
-      {
-        children: [
-          {
-            text: 'Paragraph 1',
+        {
+            children: [
+            {
+                text: "  Hello  ",
+              },
+            ],
+            type: "div",
           },
-        ],
-        type: 'p',
-      },
-    ]
-    expect(htmlToSlate(fixture)).toEqual(expected)
+        {
+            children: [
+            {
+                text: `
+
+    `,
+              },
+            ],
+          },
+        {
+            children: [
+            {
+                text: "  World!   ",
+              },
+            ],
+            type: "div",
+          },
+        {
+            children: [
+            {
+                text: ` . 
+`,
+              },
+            ],
+          },
+        ]
+      // extend the config to handle span tags
+      const config = {
+        ...htmlToSlateConfig,
+        elementTags: {
+          ...htmlToSlateConfig.elementTags,
+          div: () => ({ type: 'div' })
+        }
+      }
+      expect(htmlToSlate(fixture, config)).toEqual(expected)
+    })
+
+    /**
+     * @see https://github.com/fb55/htmlparser2/issues/90
+     */
+    it('processes the example from htmlparser2 #90', () => {
+      const fixture = '<p>foo<b> <i>bar</i></b></p>'
+      const expected: any[] = [
+        {
+          children: [
+            {
+              text: "foo",
+            },
+            {
+              text: " ",
+            },
+            {
+            italic: true,
+            text: "bar",
+            },
+          ],
+          type: "p",
+        },
+      ]
+      expect(htmlToSlate(fixture)).toEqual(expected)
+    })
+
   })
 
-  // this seems to be a side effect of using htmlparser2
-  // I haven't included this logic anywhere.
-  it('decodes HTML entities', () => {
-    const fixture = `<h1>What&#39;s Heading 1</h1>`
-    const expected = [
-      {
-        children: [
-          {
-            text: "What's Heading 1",
-          },
-        ],
-        type: 'h1',
-      },
-    ]
-    expect(htmlToSlate(fixture)).toEqual(expected)
+  describe('preserve formatting context', () => {
+    it('preserves whitespace for pre tags', () => {
+      const fixture = `<pre>  two spaces before
+      then spaces and a line break with a space after. </pre>`
+      const expected: any[] = [
+        {
+          children: [
+            {
+              code: true,
+              text: `  two spaces before
+      then spaces and a line break with a space after. `,
+            },
+          ],
+        },
+      ]
+      expect(htmlToSlate(fixture)).toEqual(expected)
+    })
   })
 })

--- a/__tests__/serializers/htmlToSlate/whitespace.spec.ts
+++ b/__tests__/serializers/htmlToSlate/whitespace.spec.ts
@@ -1,0 +1,104 @@
+import { processTextValue } from '../../../src/serializers/htmlToSlate/whitespace'
+
+describe('processTextValue function', () => {
+  describe('"preserve" context', () => {
+    it('does not do anything if the context is "preserve"', () => {
+      const fixture = ` after on space
+      and then line breaks and spaces`
+      expect(processTextValue({
+        text: fixture,
+        context: 'preserve'
+      })).toEqual(fixture)
+    })
+  })
+
+  describe('"block" context', () => {
+    const context = 'block'
+    const fixture = '   text  '
+    it('removes space from the start of a string if isInlineStart is true', () => {
+      const expected = 'text '
+      expect(processTextValue({
+        text: fixture,
+        context: context,
+        isInlineStart: true
+      })).toEqual(expected)
+    })
+
+    it('removes space from the end of a string if isInlineEnd is true', () => {
+      const expected = ' text'
+      expect(processTextValue({
+        text: fixture,
+        context: context,
+        isInlineEnd: true
+      })).toEqual(expected)
+    })
+
+    it('removes space from both ends of a string if isInlineStart and isInlineEnd is true', () => {
+      const expected = 'text'
+      expect(processTextValue({
+        text: fixture,
+        context: context,
+        isInlineStart: true,
+        isInlineEnd: true
+      })).toEqual(expected)
+    })
+  })
+
+  describe('"inline" context', () => {
+    const context = 'inline'
+    const fixture = '   text  '
+    it('normalizes space at the start of a string if isInlineStart is true', () => {
+      const expected = ' text '
+      expect(processTextValue({
+        text: fixture,
+        context: context,
+        isInlineStart: true
+      })).toEqual(expected)
+    })
+
+    it('normalizes space at the the end of a string if isInlineEnd is true', () => {
+      const expected = ' text '
+      expect(processTextValue({
+        text: fixture,
+        context: context,
+        isInlineEnd: true
+      })).toEqual(expected)
+    })
+
+    it('normalizes space at both ends of a string if isInlineStart and isInlineEnd is true', () => {
+      const expected = ' text '
+      expect(processTextValue({
+        text: fixture,
+        context: context,
+        isInlineStart: true,
+        isInlineEnd: true
+      })).toEqual(expected)
+    })
+  })
+
+  describe('"block", "inline" or "" context', () => {
+    const fixture = `before line break
+after line break`
+    const expected = 'before line break after line break'
+    it('replaces line breaks with a space in an empty context', () => {
+      expect(processTextValue({
+        text: fixture,
+        context: "",
+      })).toEqual(expected)
+    })
+
+    it('replaces line breaks with a space in an "inline" context', () => {
+      expect(processTextValue({
+        text: fixture,
+        context: "inline",
+      })).toEqual(expected)
+    })
+
+    it('replaces line breaks with a space in a "block context', () => {
+      expect(processTextValue({
+        text: fixture,
+        context: "block",
+      })).toEqual(expected)
+    })
+  })
+})

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,3 +20,12 @@ Note the `defaultTag` option that is passed in the [Payload CMS configuration fo
 At the moment, we cannot convert from `slateToHtml` to `htmlToSlate` and vice versa and expect consistent results. This is because, with the Payload conifguration, `slateToHtml` adds p tags, and then `htmlToSlate` adds these `p` tags into the Slate JSON.
 
 May be able to resolve the above by simply removing `p` tag conversion? Could possibly specify that.
+
+## Whitespace
+
+https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-minify-whitespace
+
+whitespace research
+
+- https://github.com/fb55/htmlparser2/issues/90
+- https://github.com/aknuds1/html-to-react/issues/79

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,6 +11,38 @@ Rationale for using `htmlparser2` and its associated utilities:
 - Speed - `htmlparser2` is the fastest HTML parser.
 - No need to implement our formatting/encoding logic. [`dom-serializer`](https://www.npmjs.com/package/dom-serializer) handles this.
 
+## Whitespace
+
+> The presence of whitespace in the DOM can cause layout problems and make manipulation of the content tree difficult in unexpected ways, depending on where it is located.
+
+[https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace)
+
+Developers define their own schema for Slate. For example, Payload CMS renders a default `<p>` HTML element for any nodes without a type. `<div>` elements are not mapped. This means any top-level `<div>` elements will be rendered as paragraphs. Furthermore, `slateToHtml` makes the (reasonable) assumption that these elements are paragraphs, and renders the output as such.
+
+Because we define our own schema, it's difficult to generalize rules for handling whitespace.
+
+It may be helpful to minify HTML before passing it to `htmlToSlate`. This might reduce some false positives by removing extra whitespace. Some possible solutions:
+
+- https://www.npmjs.com/package/html-minifier
+- https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-minify-whitespace
+
+### `htmlToSlate`
+
+Whitespace formatting can be customised. Default behaviour is as follows.
+
+Content for text marks follow an [inline formatting context](https://developer.mozilla.org/en-US/docs/Web/CSS/Inline_formatting_context).
+
+- reduce line breaks and surrounding space to a single space;
+- replace tabs with spaces;
+- reduce multiple spaces to a single space; and
+- remove space from the beginning and end of a block element (e.g. `h1`, `p`...etc).
+
+### References
+
+
+- https://github.com/fb55/htmlparser2/issues/90
+- https://github.com/aknuds1/html-to-react/issues/79
+
 ## Payload CMS
 
 The Slate configuration for Payload CMS results in some Slate nodes being stored with an undefined `type`. See https://github.com/payloadcms/payload/discussions/1141#discussioncomment-4255845.
@@ -21,11 +53,4 @@ At the moment, we cannot convert from `slateToHtml` to `htmlToSlate` and vice ve
 
 May be able to resolve the above by simply removing `p` tag conversion? Could possibly specify that.
 
-## Whitespace
 
-https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-minify-whitespace
-
-whitespace research
-
-- https://github.com/fb55/htmlparser2/issues/90
-- https://github.com/aknuds1/html-to-react/issues/79

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -28,17 +28,42 @@ It may be helpful to minify HTML before passing it to `htmlToSlate`. This might 
 
 ### `htmlToSlate`
 
-Whitespace formatting can be customised. Default behaviour is as follows.
+Whitespace in text nodes is processed depending on context.
 
 Content for text marks follow an [inline formatting context](https://developer.mozilla.org/en-US/docs/Web/CSS/Inline_formatting_context).
 
 - reduce line breaks and surrounding space to a single space;
 - replace tabs with spaces;
 - reduce multiple spaces to a single space; and
-- remove space from the beginning and end of a block element (e.g. `h1`, `p`...etc).
+- remove space from the beginning and end of the contents of a block element (e.g. `h1`, `p`...etc).
+
+Before:
+
+```
+<p>
+  <b>
+    <i>bar</i></b>
+</p>
+```
+
+After:
+
+```
+<p>foo<b> <i>bar</i></b></p>
+```
+
+Block elements follow a [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context).
+
+By default, the `filterWhitespaceNodes` is set to `true`. This option removes nodes from the Slate JSON object that:
+
+- contain only whitespace; and
+- have no context.
+
+This helps when passing a HTML string that uses line breaks/tabs/spaces to make the document more readable. These spaces do not add any meaning to the document, and so it isn't helpful to represent them in the Slate JSON. Furthermore, depending on the schema, these nodes may be interpreted as elements or part of the content.
+
+For text nodes inside `<code>` and/or `<pre>` HTML elements, whitespace is preserved.
 
 ### References
-
 
 - https://github.com/fb55/htmlparser2/issues/90
 - https://github.com/aknuds1/html-to-react/issues/79

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.13",
       "license": "ISC",
       "dependencies": {
-        "css-select": "^5.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
@@ -23,6 +22,7 @@
         "@types/html-escaper": "^3.0.0",
         "@types/jest": "^29.2.3",
         "commitizen": "^4.2.5",
+        "css-select": "^5.1.0",
         "cz-conventional-changelog": "^3.3.0",
         "husky": "^8.0.2",
         "jest": "^29.3.1",
@@ -2359,7 +2359,8 @@
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3235,6 +3236,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
       "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -3250,6 +3252,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       },
@@ -6909,6 +6912,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -10458,7 +10462,8 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -11121,6 +11126,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
       "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -11132,7 +11138,8 @@
     "css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true
     },
     "cz-conventional-changelog": {
       "version": "3.3.0",
@@ -13861,6 +13868,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
       }

--- a/src/config/htmlToSlate/default.ts
+++ b/src/config/htmlToSlate/default.ts
@@ -8,6 +8,7 @@ interface ItagMap {
 export interface Config {
   elementTags: ItagMap
   textTags: ItagMap
+  filterWhitespaceNodes: boolean
 }
 
 export const config: Config = {
@@ -39,4 +40,5 @@ export const config: Config = {
     strong: () => ({ bold: true }),
     u: () => ({ underline: true }),
   },
+  filterWhitespaceNodes: true // remove whitespace nodes that do not contribute meaning
 }

--- a/src/config/htmlToSlate/default.ts
+++ b/src/config/htmlToSlate/default.ts
@@ -40,5 +40,5 @@ export const config: Config = {
     strong: () => ({ bold: true }),
     u: () => ({ underline: true }),
   },
-  filterWhitespaceNodes: true // remove whitespace nodes that do not contribute meaning
+  filterWhitespaceNodes: true, // remove whitespace nodes that do not contribute meaning
 }

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -126,7 +126,7 @@ export const htmlToSlate = (html: string, config: Config = defaultConfig) => {
         .filter((element) => !isSlateDeadEnd(element))
     }
   })
-  const parser = new Parser(handler)
+  const parser = new Parser(handler, {decodeEntities: false})
   parser.write(html)
   parser.end()
   return slateContent

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -1,13 +1,20 @@
 import { jsx } from 'slate-hyperscript'
 import { Parser, ElementType } from 'htmlparser2'
 import { ChildNode, DomHandler, Element } from 'domhandler'
-import { getAttributeValue, getChildren, getName, textContent } from 'domutils'
-import { hasLineBreak } from '../../utilities'
-import { IattributeMap } from '../../types'
+import { getChildren, getName, textContent } from 'domutils'
+import { getContext, minifyText } from './whitespace'
 
 import { config as defaultConfig, Config } from '../../config/htmlToSlate/default'
 
-const deserialize = (el: ChildNode, config: Config = defaultConfig): any => {
+interface Ideserialize {
+  el: ChildNode
+  config?: Config
+  index?: number
+  childrenLength?: number
+  context?: string
+}
+
+const deserialize = ({el, config = defaultConfig, index = 0, childrenLength = 0, context = ''}: Ideserialize): any => {
   if (el.type !== ElementType.Tag && el.type !== ElementType.Text) {
     return null
   }
@@ -18,7 +25,15 @@ const deserialize = (el: ChildNode, config: Config = defaultConfig): any => {
 
   const nodeName = getName(parent)
 
-  const children = parent.childNodes ? parent.childNodes.map((node) => deserialize(node, config)).flat() : []
+  const childrenContext = getContext(nodeName) || context
+
+  const children = parent.childNodes ? parent.childNodes.map((node, i) => deserialize({
+    el: node,
+    config,
+    index: i,
+    childrenLength: parent.childNodes.length,
+    context: childrenContext
+  })).flat() : []
 
   if (getName(parent) === 'body') {
     return jsx('fragment', {}, children)
@@ -30,20 +45,44 @@ const deserialize = (el: ChildNode, config: Config = defaultConfig): any => {
   }
 
   if (config.textTags[nodeName] || el.type === ElementType.Text) {
-    return [jsx('text', gatherTextMarkAttributes(parent), [])]
+    const attrs = gatherTextMarkAttributes({el: parent, context: childrenContext})
+    let text = (attrs as { text: string}).text
+    const isInlineStart = index === 0
+    const isInlineEnd = Number.isInteger(childrenLength) && index === (childrenLength - 1)
+    if (context === 'block') {
+      // is this the start of inline content after a block element?
+      if (isInlineStart) {
+        text = text.trimStart()
+      }
+      // is this the end of inline content in a block element?
+      if (isInlineEnd) {
+        text = text.trimEnd()
+      }
+    }
+    return [jsx('text', {...attrs, text}, [])]
   }
 
   return children
 }
 
-const gatherTextMarkAttributes = (el: Element, config: Config = defaultConfig) => {
+interface IgatherTextMarkAttributes {
+  el: Element
+  config?: Config
+  context?: string
+}
+
+const gatherTextMarkAttributes = ({
+  el,
+  config = defaultConfig,
+  context = ''
+}: IgatherTextMarkAttributes) => {
   let allAttrs = {}
   // tslint:disable-next-line no-unused-expression
   if (el.childNodes) {
     ;[el, ...getChildren(el).flat()].forEach((child) => {
       const name = getName(child as Element)
       const attrs = config.textTags[name] ? config.textTags[name](child as Element) : {}
-      const text = textContent(child)
+      const text = context === 'preserve' ? textContent(child) : minifyText(textContent(child))
       allAttrs = {
         ...allAttrs,
         ...attrs,
@@ -53,12 +92,12 @@ const gatherTextMarkAttributes = (el: Element, config: Config = defaultConfig) =
   } else {
     const name = getName(el)
     const attrs = config.textTags[name] ? config.textTags[name](el) : {}
-    const text = textContent(el)
+    const text = context === 'preserve' ? textContent(el) : minifyText(textContent(el))
     allAttrs = {
       ...attrs,
       text,
     }
-  }
+  } 
   return allAttrs
 }
 
@@ -70,7 +109,7 @@ export const htmlToSlate = (html: string, config: Config = defaultConfig) => {
     } else {
       // Parsing completed, do something
       slateContent = dom
-        .map((node) => deserialize(node, config)) // run the deserializer
+        .map((node) => deserialize({el: node, config})) // run the deserializer
         .filter((element) => element) // filter out null elements
         .map((element) => {
           // ensure all top level elements have a children property

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -14,7 +14,13 @@ interface Ideserialize {
   context?: string
 }
 
-const deserialize = ({el, config = defaultConfig, index = 0, childrenLength = 0, context = ''}: Ideserialize): any => {
+const deserialize = ({
+  el,
+  config = defaultConfig,
+  index = 0,
+  childrenLength = 0,
+  context = '',
+}: Ideserialize): any => {
   if (el.type !== ElementType.Tag && el.type !== ElementType.Text) {
     return null
   }
@@ -27,13 +33,21 @@ const deserialize = ({el, config = defaultConfig, index = 0, childrenLength = 0,
 
   const childrenContext = getContext(nodeName) || context
 
-  const children = parent.childNodes ? parent.childNodes.map((node, i) => deserialize({
-    el: node,
-    config,
-    index: i,
-    childrenLength: parent.childNodes.length,
-    context: childrenContext
-  })).filter((element) => element).filter((element) => !isSlateDeadEnd(element)).flat() : []
+  const children = parent.childNodes
+    ? parent.childNodes
+        .map((node, i) =>
+          deserialize({
+            el: node,
+            config,
+            index: i,
+            childrenLength: parent.childNodes.length,
+            context: childrenContext,
+          }),
+        )
+        .filter((element) => element)
+        .filter((element) => !isSlateDeadEnd(element))
+        .flat()
+    : []
 
   if (getName(parent) === 'body') {
     return jsx('fragment', {}, children)
@@ -45,10 +59,10 @@ const deserialize = ({el, config = defaultConfig, index = 0, childrenLength = 0,
   }
 
   if (config.textTags[nodeName] || el.type === ElementType.Text) {
-    const attrs = gatherTextMarkAttributes({el: parent, context: childrenContext})
-    let text = (attrs as { text: string}).text
+    const attrs = gatherTextMarkAttributes({ el: parent, context: childrenContext })
+    let text = (attrs as { text: string }).text
     const isInlineStart = index === 0
-    const isInlineEnd = Number.isInteger(childrenLength) && index === (childrenLength - 1)
+    const isInlineEnd = Number.isInteger(childrenLength) && index === childrenLength - 1
     if (context === 'block') {
       // is this the start of inline content after a block element?
       if (isInlineStart) {
@@ -62,7 +76,7 @@ const deserialize = ({el, config = defaultConfig, index = 0, childrenLength = 0,
     if ((config.filterWhitespaceNodes && isAllWhitespace(text) && !childrenContext) || text === '') {
       return null
     }
-    return [jsx('text', {...attrs, text}, [])]
+    return [jsx('text', { ...attrs, text }, [])]
   }
 
   return children
@@ -74,11 +88,7 @@ interface IgatherTextMarkAttributes {
   context?: string
 }
 
-const gatherTextMarkAttributes = ({
-  el,
-  config = defaultConfig,
-  context = ''
-}: IgatherTextMarkAttributes) => {
+const gatherTextMarkAttributes = ({ el, config = defaultConfig, context = '' }: IgatherTextMarkAttributes) => {
   let allAttrs = {}
   // tslint:disable-next-line no-unused-expression
   if (el.childNodes) {
@@ -100,7 +110,7 @@ const gatherTextMarkAttributes = ({
       ...attrs,
       text,
     }
-  } 
+  }
   return allAttrs
 }
 
@@ -112,8 +122,8 @@ export const htmlToSlate = (html: string, config: Config = defaultConfig) => {
     } else {
       // Parsing completed, do something
       slateContent = dom
-        .map((node) => deserialize({el: node, config})) // run the deserializer
-        .filter(element => element) // filter out null elements
+        .map((node) => deserialize({ el: node, config })) // run the deserializer
+        .filter((element) => element) // filter out null elements
         .map((element) => {
           // ensure all top level elements have a children property
           if (!element.children) {
@@ -126,7 +136,7 @@ export const htmlToSlate = (html: string, config: Config = defaultConfig) => {
         .filter((element) => !isSlateDeadEnd(element))
     }
   })
-  const parser = new Parser(handler, {decodeEntities: false})
+  const parser = new Parser(handler, { decodeEntities: false })
   parser.write(html)
   parser.end()
   return slateContent

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -30,10 +30,6 @@ const deserialize = (el: ChildNode, config: Config = defaultConfig): any => {
   }
 
   if (config.textTags[nodeName] || el.type === ElementType.Text) {
-    const text = textContent(el)
-    if (!hasLineBreak(text) && text.trim() === '') {
-      return null
-    }
     return [jsx('text', gatherTextMarkAttributes(parent), [])]
   }
 

--- a/src/serializers/htmlToSlate/whitespace.ts
+++ b/src/serializers/htmlToSlate/whitespace.ts
@@ -1,0 +1,95 @@
+export const minifyText = (str: string) => {
+  return reduceToSingleSpaces(replaceNewlines(str))
+}
+
+const replaceNewlines = (str: string) => {
+  return str.replace(/(?:\r\n|\r|\n)/g, ' ')
+}
+
+const reduceToSingleSpaces = (str: string) => {
+  return str.replace(/ +(?= )/g, '')
+}
+
+export const getContext = (tagName: string): 'preserve' | 'block' | 'inline' | '' => {
+  if (!tagName || tagName.trim() === '') {
+    return ''
+  }
+  if (preserveWhitespace(tagName)) {
+    return 'preserve'
+  }
+  if (isBlock(tagName)) {
+    return 'block'
+  }
+  return 'inline'
+}
+
+const isBlock = (tagName: string) => {
+  return blocks.includes(tagName)
+}
+
+const preserveWhitespace = (tagName: string) => {
+  return ['code', 'pre', 'xmp'].includes(tagName)
+}
+
+// See: <https://html.spec.whatwg.org/#the-css-user-agent-style-sheet-and-presentational-hints>
+// From: https://www.npmjs.com/package/rehype-minify-whitespace
+const blocks = [
+  'address', // Flow content.
+  'article', // Sections and headings.
+  'aside', // Sections and headings.
+  'blockquote', // Flow content.
+  'body', // Page.
+  'br', // Contribute whitespace intrinsically.
+  'caption', // Similar to block.
+  'center', // Flow content, legacy.
+  'col', // Similar to block.
+  'colgroup', // Similar to block.
+  'dd', // Lists.
+  'dialog', // Flow content.
+  'dir', // Lists, legacy.
+  'div', // Flow content.
+  'dl', // Lists.
+  'dt', // Lists.
+  'figcaption', // Flow content.
+  'figure', // Flow content.
+  'footer', // Flow content.
+  'form', // Flow content.
+  'h1', // Sections and headings.
+  'h2', // Sections and headings.
+  'h3', // Sections and headings.
+  'h4', // Sections and headings.
+  'h5', // Sections and headings.
+  'h6', // Sections and headings.
+  'head', // Page.
+  'header', // Flow content.
+  'hgroup', // Sections and headings.
+  'hr', // Flow content.
+  'html', // Page.
+  'legend', // Flow content.
+  'li', // Block-like.
+  'li', // Similar to block.
+  'listing', // Flow content, legacy
+  'main', // Flow content.
+  'menu', // Lists.
+  'nav', // Sections and headings.
+  'ol', // Lists.
+  'optgroup', // Similar to block.
+  'option', // Similar to block.
+  'p', // Flow content.
+  'plaintext', // Flow content, legacy
+  'pre', // Flow content.
+  'section', // Sections and headings.
+  'summary', // Similar to block.
+  'table', // Similar to block.
+  'tbody', // Similar to block.
+  'td', // Block-like.
+  'td', // Similar to block.
+  'tfoot', // Similar to block.
+  'th', // Block-like.
+  'th', // Similar to block.
+  'thead', // Similar to block.
+  'tr', // Similar to block.
+  'ul', // Lists.
+  'wbr', // Contribute whitespace intrinsically.
+  'xmp' // Flow content, legacy
+]

--- a/src/serializers/htmlToSlate/whitespace.ts
+++ b/src/serializers/htmlToSlate/whitespace.ts
@@ -10,6 +10,10 @@ const reduceToSingleSpaces = (str: string) => {
   return str.replace(/ +(?= )/g, '')
 }
 
+export const isAllWhitespace = (str: string) => {
+  return !(/[^\t\n\r ]/.test(str))
+}
+
 export const getContext = (tagName: string): 'preserve' | 'block' | 'inline' | '' => {
   if (!tagName || tagName.trim() === '') {
     return ''

--- a/src/serializers/htmlToSlate/whitespace.ts
+++ b/src/serializers/htmlToSlate/whitespace.ts
@@ -11,7 +11,7 @@ const reduceToSingleSpaces = (str: string) => {
 }
 
 export const isAllWhitespace = (str: string) => {
-  return !(/[^\t\n\r ]/.test(str))
+  return !/[^\t\n\r ]/.test(str)
 }
 
 export const getContext = (tagName: string): 'preserve' | 'block' | 'inline' | '' => {
@@ -95,5 +95,5 @@ const blocks = [
   'tr', // Similar to block.
   'ul', // Lists.
   'wbr', // Contribute whitespace intrinsically.
-  'xmp' // Flow content, legacy
+  'xmp', // Flow content, legacy
 ]

--- a/src/serializers/htmlToSlate/whitespace.ts
+++ b/src/serializers/htmlToSlate/whitespace.ts
@@ -1,3 +1,36 @@
+export type Context = 'preserve' | 'block' | 'inline' | ''
+
+interface IprocessTextValue {
+  text: string
+  context?: Context
+  isInlineStart?: boolean
+  isInlineEnd?: boolean
+}
+
+export const processTextValue = ({
+  text,
+  context = '',
+  isInlineStart = false,
+  isInlineEnd = false,
+}: IprocessTextValue): string => {
+  let parsed = text
+  if (context === 'preserve') {
+    return parsed
+  }
+  parsed = minifyText(parsed)
+  if (context === 'block') {
+    // is this the start of inline content after a block element?
+    if (isInlineStart) {
+      parsed = parsed.trimStart()
+    }
+    // is this the end of inline content in a block element?
+    if (isInlineEnd) {
+      parsed = parsed.trimEnd()
+    }
+  }
+  return parsed
+}
+
 export const minifyText = (str: string) => {
   return reduceToSingleSpaces(replaceNewlines(str))
 }
@@ -14,7 +47,7 @@ export const isAllWhitespace = (str: string) => {
   return !/[^\t\n\r ]/.test(str)
 }
 
-export const getContext = (tagName: string): 'preserve' | 'block' | 'inline' | '' => {
+export const getContext = (tagName: string): Context => {
   if (!tagName || tagName.trim() === '') {
     return ''
   }


### PR DESCRIPTION
Process whitespace depending on context.

- If within `code` or `pre` tags, don't do any processing.
- If within a [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context), normalize whitespace and remove space from the beginning and end of the block contents.
- If within an [inline formatting context](https://developer.mozilla.org/en-US/docs/Web/CSS/Inline_formatting_context), normalize whitespace.

This type of processing means that some Slate nodes can become empty. Additional filtering is added to clean up these empty nodes that do not add any meaning.

Docs added within the pull request.