### PR TITLE
fix(htmltoslate): ensure empty children have a text node

### DIFF
--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -305,10 +305,36 @@ describe('inline code and pre HTML elements', () => {
         ]
       },
       {
-        children: [],
+        children: [
+          {
+            text: ""
+          }
+        ],
         type: "p",
       },
     ]
     expect(htmlToSlate(html)).toEqual(slate)
+  })
+})
+
+describe('normalize slate JSON object', () => {
+  /**
+   * @see https://docs.slatejs.org/concepts/11-normalizing
+   */
+  describe('ensure empty children have an empty text node', () => {
+    it('adds an empty text node for an invalid paragrapf', () => {
+      const html = "<p>"
+      const slate: any[] = [
+          {
+            children: [
+              {
+                text: ""
+              }
+            ],
+            type: "p",
+          },
+        ]
+      expect(htmlToSlate(html)).toEqual(slate)
+    })
   })
 })

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -52,7 +52,7 @@ const deserialize = ({
         )
         .filter((element) => element)
         .filter((element) => !isSlateDeadEnd(element))
-        .map(element => addTextNodeToEmptyChildren(element))
+        .map((element) => addTextNodeToEmptyChildren(element))
         .flat()
     : []
 
@@ -154,7 +154,7 @@ export const htmlToSlate = (html: string, config: Config = defaultConfig) => {
           return element
         })
         .filter((element) => !isSlateDeadEnd(element))
-        .map(element => addTextNodeToEmptyChildren(element))
+        .map((element) => addTextNodeToEmptyChildren(element))
     }
   })
   const parser = new Parser(handler, { decodeEntities: false })
@@ -175,8 +175,8 @@ const isSlateDeadEnd = (element: { children: [] }) => {
 
 const addTextNodeToEmptyChildren = (element: { children: any[] }) => {
   if (!('children' in element)) return element
-  if ( element.children.length === 0 ) {
-    element.children.push({ text: "" })
+  if (element.children.length === 0) {
+    element.children.push({ text: '' })
   }
   return element
 }

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -52,6 +52,7 @@ const deserialize = ({
         )
         .filter((element) => element)
         .filter((element) => !isSlateDeadEnd(element))
+        .map(element => addTextNodeToEmptyChildren(element))
         .flat()
     : []
 
@@ -153,6 +154,7 @@ export const htmlToSlate = (html: string, config: Config = defaultConfig) => {
           return element
         })
         .filter((element) => !isSlateDeadEnd(element))
+        .map(element => addTextNodeToEmptyChildren(element))
     }
   })
   const parser = new Parser(handler, { decodeEntities: false })
@@ -169,4 +171,12 @@ const isSlateDeadEnd = (element: { children: [] }) => {
   const keys = Object.keys(element)
   if (!('children' in element)) return false
   return element.children.length === 0 && keys.length === 1
+}
+
+const addTextNodeToEmptyChildren = (element: { children: any[] }) => {
+  if (!('children' in element)) return element
+  if ( element.children.length === 0 ) {
+    element.children.push({ text: "" })
+  }
+  return element
 }


### PR DESCRIPTION
> All Element nodes must contain at least one Text descendant — even [Void Elements](https://github.com/concepts/02-nodes#voids). If an element node does not contain any children, an empty text node will be added as its only child.

https://docs.slatejs.org/concepts/11-normalizing