### PR TITLE
fix: error when parsing empty or self-closing tags

### DIFF
--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -315,7 +315,7 @@ describe('normalize slate JSON object', () => {
    * @see https://docs.slatejs.org/concepts/11-normalizing
    */
   describe('ensure empty children have an empty text node', () => {
-    it('adds an empty text node for an invalid paragrapf', () => {
+    it('adds an empty text node for an invalid paragraph', () => {
       const html = "<p>"
       const slate: any[] = [
           {
@@ -328,6 +328,70 @@ describe('normalize slate JSON object', () => {
           },
         ]
       expect(htmlToSlate(html)).toEqual(slate)
+    })
+  })
+})
+
+describe('empty content', () => {
+  /**
+   * @see https://docs.slatejs.org/concepts/11-normalizing
+   */
+  describe('ensure empty children have an empty text node', () => {
+    it('adds an empty text node for an invalid paragraph', () => {
+      const html = "<p></p>"
+      const slate: any[] = [
+          {
+            children: [
+              {
+                text: ""
+              }
+            ],
+            type: "p",
+          },
+        ]
+      expect(htmlToSlate(html)).toEqual(slate)
+    })
+
+    it('converts a br tag to a line break', () => {
+      const html = "<br />"
+      const slate: any[] = [
+          {
+            children:[
+              {
+                text: "\n",
+              },
+            ],
+          },
+        ]
+      expect(htmlToSlate(html)).toEqual(slate)
+    })
+
+    it('does nothing with a br tag if convertBrToLineBreak is false', () => {
+      const html = "<br />"
+      const slate: any[] = []
+      expect(htmlToSlate(html, {...htmlToSlateConfig, convertBrToLineBreak: false})).toEqual(slate)
+    })
+
+    it('converts a br tag to a slate node if defined as an element tag', () => {
+      const html = "<br />"
+      const slate: any[] = [
+          {
+            children:[
+              {
+                text: "",
+              },
+            ],
+            type: "br",
+          },
+        ]
+      expect(htmlToSlate(html, {
+        ...htmlToSlateConfig,
+        convertBrToLineBreak: false,
+        elementTags: {
+          ...htmlToSlateConfig.elementTags,
+          br: () => ({type: 'br'})
+        }
+      })).toEqual(slate)
     })
   })
 })

--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -333,9 +333,6 @@ describe('normalize slate JSON object', () => {
 })
 
 describe('empty content', () => {
-  /**
-   * @see https://docs.slatejs.org/concepts/11-normalizing
-   */
   describe('ensure empty children have an empty text node', () => {
     it('adds an empty text node for an invalid paragraph', () => {
       const html = "<p></p>"

--- a/__tests__/serializers/slateToHtml/index.spec.ts
+++ b/__tests__/serializers/slateToHtml/index.spec.ts
@@ -91,9 +91,6 @@ describe('slateToHtml expected behaviour', () => {
 })
 
 describe('empty content', () => {
-  /**
-   * @see https://docs.slatejs.org/concepts/11-normalizing
-   */
   describe('ensure empty children have an empty text node', () => {
     it('adds an empty text node for an invalid paragraph', () => {
       const html = "<p></p>"

--- a/__tests__/serializers/slateToHtml/index.spec.ts
+++ b/__tests__/serializers/slateToHtml/index.spec.ts
@@ -89,3 +89,36 @@ describe('slateToHtml expected behaviour', () => {
     expect(slateToHtml(slate, { ...slateToDomConfig, encodeEntities: false, alwaysEncodeCodeEntities: true })).toEqual(html)
   })
 })
+
+describe('empty content', () => {
+  /**
+   * @see https://docs.slatejs.org/concepts/11-normalizing
+   */
+  describe('ensure empty children have an empty text node', () => {
+    it('adds an empty text node for an invalid paragraph', () => {
+      const html = "<p></p>"
+      const slate: any[] = [
+          {
+            children: [
+              {
+                text: ""
+              }
+            ],
+            type: "p",
+          },
+        ]
+      expect(slateToHtml(slate)).toEqual(html)
+    })
+
+    it('adds an empty text node for an invalid paragraph', () => {
+      const html = ""
+      const slate: any[] = [
+          {
+            children: [],
+            type: "br",
+          },
+        ]
+      expect(slateToHtml(slate)).toEqual(html)
+    })
+  })
+})

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -98,3 +98,11 @@ Note that in the default configuration, all HTML entities are encoded.
 ### `htmlToslate`
 
 `htmlToSlate` will always encode HTML entities. There is no option to disable this behaviour. This is because in a Slate editor, we do not expect to find any HTML entity codes. As mentioned in the introduction, Slate should be as unaware of HTML as possible.
+
+## Line breaks
+
+### `htmlToSlate`
+
+`br` HTML elements get special treatment. The default configuration sets `convertBrToLineBreak` to `true`, and each `br` HTML element will be converted to a text node in Slate that contains `\n`.
+
+If you have schema rules that process `br` tags (e.g. in `elementTags` in the configuration), you may choose to disable this behaviour by setting `convertBrToLineBreak` to `false`.

--- a/src/config/htmlToSlate/default.ts
+++ b/src/config/htmlToSlate/default.ts
@@ -31,4 +31,5 @@ export const config: HtmlToSlateConfig = {
     u: () => ({ underline: true }),
   },
   filterWhitespaceNodes: true, // remove whitespace nodes that do not contribute meaning
+  convertBrToLineBreak: true,
 }

--- a/src/config/htmlToSlate/types.ts
+++ b/src/config/htmlToSlate/types.ts
@@ -16,6 +16,7 @@ export interface Config {
   htmlPreProcessString?: (html: string) => string
   htmlUpdaterMap?: HtmlUpdaterFunctionMap
   filterWhitespaceNodes: boolean
+  convertBrToLineBreak?: boolean
 }
 
 type UpdaterFunction = (el: Element) => Element | string

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -31,8 +31,8 @@ const deserialize = ({
     return null
   }
   const parent = el as Element
-  if (getName(parent) === 'br') {
-    return '\n'
+  if (getName(parent) === 'br' && config.convertBrToLineBreak) {
+    return [jsx('text', { text: '\n' }, [])]
   }
 
   const nodeName = getName(parent)
@@ -167,15 +167,15 @@ export const htmlToSlate = (html: string, config: Config = defaultConfig) => {
   return slateContent
 }
 
-const isSlateDeadEnd = (element: { children: [] } | string) => {
+const isSlateDeadEnd = (element: { children: [] }) => {
   const keys = Object.keys(element)
-  if (!keys.includes('children')) return false
+  if (!('children' in element)) return false
   return element.children.length === 0 && keys.length === 1
 }
 
-const addTextNodeToEmptyChildren = (element: { children: any[] } | string) => {
+const addTextNodeToEmptyChildren = (element: { children: any[] }) => {
   const keys = Object.keys(element)
-  if (!keys.includes('children')) return element
+  if (!('children' in element)) return element
   if (element.children.length === 0) {
     element.children.push({ text: '' })
   }

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -167,14 +167,15 @@ export const htmlToSlate = (html: string, config: Config = defaultConfig) => {
   return slateContent
 }
 
-const isSlateDeadEnd = (element: { children: [] }) => {
+const isSlateDeadEnd = (element: { children: [] } | string) => {
   const keys = Object.keys(element)
-  if (!('children' in element)) return false
+  if (!keys.includes('children')) return false
   return element.children.length === 0 && keys.length === 1
 }
 
-const addTextNodeToEmptyChildren = (element: { children: any[] }) => {
-  if (!('children' in element)) return element
+const addTextNodeToEmptyChildren = (element: { children: any[] } | string) => {
+  const keys = Object.keys(element)
+  if (!keys.includes('children')) return element
   if (element.children.length === 0) {
     element.children.push({ text: '' })
   }


### PR DESCRIPTION
When parsing the following examples, the serializer would break with the following errors

```sh
/node_modules/slate-serializers/lib/serializers/htmlToSlate/index.js:149
    if (!('children' in element))
                     ^

TypeError: Cannot use 'in' operator to search for 'children' in

    at isSlateDeadEnd (/node_modules/slate-serializers/lib/serializers/htmlToSlate/index.js:145:22)
    at /node_modules/slate-serializers/lib/serializers/htmlToSlate/index.js:34:31
    at Array.map (<anonymous>)
    ...
```

This happens at `isSlateDeadEnd` and `addTextNodeToEmptyChildren` methods. The reason is that for self-closing tags like `<br>` and tags with empty contents like `<p></p>` the element these functions receive is an empty string instead of elements. The `in` operator works perfectly for objects, but not for empty strings

This change patches this issue atleast on the surface