### PR TITLE
refactor(config): extend all config from a sensible default

### DIFF
--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -247,67 +247,6 @@ describe('inline code and pre HTML elements', () => {
     ]
     expect(htmlToSlate(html)).toEqual(slate)
   })
-
-  /**
-   * Note that unlike <code> tags, <pre> tags get
-   * separated out.
-   * 
-   * This differs from the Slate example.
-   * 
-   * Wondering if this comes from the way htmlparser2
-   * translates into a DOM document object?
-   */
-  it('can handle inline code tags', () => {
-    const html = '<p>This is editable <strong>rich</strong> text, <i>much</i> better than a <pre>&lt;textarea&gt;</pre>!</p>'
-    const slate = [
-      {
-        type: 'p',
-        children: [
-          {
-            text: 'This is editable '
-          },
-          {
-            text: 'rich',
-            bold: true
-          },
-          {
-            text: ' text, '
-          },
-          {
-            text: 'much',
-            italic: true
-          },
-          {
-            text: ' better than a'
-          }
-        ]
-      },
-      {
-        children: [
-          {
-            text: '<textarea>',
-            code: true
-          }
-        ]
-      },
-      {
-        children: [
-          {
-            text: '!'
-          }
-        ]
-      },
-      {
-        children: [
-          {
-            text: ""
-          }
-        ],
-        type: "p",
-      },
-    ]
-    expect(htmlToSlate(html)).toEqual(slate)
-  })
 })
 
 describe('normalize slate JSON object', () => {

--- a/src/config/htmlToSlate/default.ts
+++ b/src/config/htmlToSlate/default.ts
@@ -2,6 +2,9 @@ import { getAttributeValue } from 'domutils'
 import { HtmlToSlateConfig } from '../../'
 
 export const config: HtmlToSlateConfig = {
+  elementStyleMap: {
+    align: 'textAlign',
+  },
   elementTags: {
     a: (el) => ({
       type: 'link',
@@ -30,6 +33,7 @@ export const config: HtmlToSlateConfig = {
     strong: () => ({ bold: true }),
     u: () => ({ underline: true }),
   },
-  filterWhitespaceNodes: true, // remove whitespace nodes that do not contribute meaning
+  htmlPreProcessString: (html) => html.replace(/<pre[^>]*>/g, '<code>').replace(/<\/pre>/g, '</code>'),
+  filterWhitespaceNodes: true,
   convertBrToLineBreak: true,
 }

--- a/src/config/htmlToSlate/slateDemo.ts
+++ b/src/config/htmlToSlate/slateDemo.ts
@@ -1,9 +1,8 @@
 import { HtmlToSlateConfig } from '../../'
+import { config as defaultConfig } from './default'
 
 export const config: HtmlToSlateConfig = {
-  elementStyleMap: {
-    align: 'textAlign',
-  },
+  ...defaultConfig,
   elementTags: {
     blockquote: () => ({
       type: 'block-quote',
@@ -27,16 +26,4 @@ export const config: HtmlToSlateConfig = {
       type: 'paragraph',
     }),
   },
-  textTags: {
-    code: () => ({ code: true }),
-    pre: () => ({ code: true }),
-    del: () => ({ strikethrough: true }),
-    em: () => ({ italic: true }),
-    i: () => ({ italic: true }),
-    s: () => ({ strikethrough: true }),
-    strong: () => ({ bold: true }),
-    u: () => ({ underline: true }),
-  },
-  htmlPreProcessString: (html) => html.replace(/<pre[^>]*>/g, '<code>').replace(/<\/pre>/g, '</code>'),
-  filterWhitespaceNodes: true,
 }

--- a/src/config/htmlToSlate/types.ts
+++ b/src/config/htmlToSlate/types.ts
@@ -4,18 +4,29 @@ interface ItagMap {
   [key: string]: (a?: Element) => object
 }
 
+/**
+ * @see /docs/config/htmlToSlate.md
+ */
 export interface Config {
+  /* Shortcut to map all HTML attribute/values */
   elementAttributeMap?: {
     style?: { [key: string]: string }
   }
+  /* Shortcut to map CSS attribute/values in an inline HTML style attribute */
   elementStyleMap?: {
     [key: string]: string
   }
+  /* Map HTML element tags to Slate JSON object attributes */
   elementTags: ItagMap
+  /* Map HTML text tags to Slate JSON object attributes */
   textTags: ItagMap
+  /* Perform string operations on the html string before it is parsed to a DOM Document Object Model */
   htmlPreProcessString?: (html: string) => string
+  /* Pass updater functions to modify HTML */
   htmlUpdaterMap?: HtmlUpdaterFunctionMap
+  /* Remove whitespace that does not contribute meaning */
   filterWhitespaceNodes: boolean
+  /* Convert br tags to a new line character (\n) */
   convertBrToLineBreak?: boolean
 }
 

--- a/src/config/htmlToSlate/types.ts
+++ b/src/config/htmlToSlate/types.ts
@@ -5,6 +5,7 @@ interface ItagMap {
 }
 
 /**
+ * For details on configuration options:
  * @see /docs/config/htmlToSlate.md
  */
 export interface Config {


### PR DESCRIPTION
Extend both the `slateDemo` and `payload` config from a sensible default config.