### PR TITLE
fix(html-to-slate): trim whitespace that precedes a block element

### DIFF
--- a/__tests__/serializers/combined/fixtures/elementTags.ts
+++ b/__tests__/serializers/combined/fixtures/elementTags.ts
@@ -1,6 +1,7 @@
 interface Ifixture {
   name: string
   html: string
+  htmlFromSlate?: string
   slate: object[]
 }
 
@@ -132,7 +133,16 @@ export const fixtures: Ifixture[] = [
   },
   {
     name: 'nested unordered list',
-    html: '<ul><li>Item 1<ul><li>Nested item 1</li><li>Nested item 2</li></ul></li><li>Item 2</li></ul>',
+    html: `<ul>
+        <li>Item 1
+          <ul>
+            <li>Nested item 1</li>
+            <li>Nested item 2</li>
+          </ul>
+        </li>
+        <li>Item 2</li>
+      </ul>`,
+    htmlFromSlate: `<ul><li>Item 1<ul><li>Nested item 1</li><li>Nested item 2</li></ul></li><li>Item 2</li></ul>`,
     slate: [
       {
         children: [

--- a/__tests__/serializers/combined/sameHtmlSlateBothWays.spec.ts
+++ b/__tests__/serializers/combined/sameHtmlSlateBothWays.spec.ts
@@ -38,7 +38,7 @@ describe('Slate JSON to HTML transforms', () => {
     const fixtures = elementFixtures
     for (const fixture of fixtures) {
       it(`${fixture.name}`, () => {
-        expect(slateToHtml(fixture.slate)).toEqual(fixture.html)
+        expect(slateToHtml(fixture.slate)).toEqual(fixture.htmlFromSlate || fixture.html)
       })
     }
   })

--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -291,12 +291,26 @@ describe('empty content', () => {
     })
 
     it('converts a br tag to a line break', () => {
-      const html = '<br />'
+      const html = 'Line 1<br />Line 2'
       const slate: any[] = [
         {
           children: [
             {
-              text: '\n',
+              text: 'Line 1',
+            },
+          ],
+        },
+        {
+          children: [
+            {
+              text: '',
+            },
+          ],
+        },
+        {
+          children: [
+            {
+              text: 'Line 2',
             },
           ],
         },
@@ -354,6 +368,39 @@ describe('empty content', () => {
             ...htmlToSlateConfig.elementTags,
             br: () => ({ type: 'br' }),
           },
+        }),
+      ).toEqual(slate)
+    })
+
+    it('adds an empty text element in place of a br tag as a line break', () => {
+      const html = 'Line 1<br>\n<span>Line 2</span>'
+      const slate: any[] = [
+        {
+          children: [
+            {
+              text: 'Line 1',
+            },
+          ],
+        },
+        {
+          children: [
+            {
+              text: '',
+            },
+          ],
+        },
+        {
+          children: [
+            {
+              text: 'Line 2',
+            },
+          ],
+        },
+      ]
+      expect(
+        htmlToSlate(html, {
+          ...htmlToSlateConfig,
+          convertBrToLineBreak: true,
         }),
       ).toEqual(slate)
     })

--- a/__tests__/serializers/slateToHtml/index.spec.ts
+++ b/__tests__/serializers/slateToHtml/index.spec.ts
@@ -228,4 +228,24 @@ describe('line breaks', () => {
     const html = '<p>Paragraph with <br> line<br><br>breaks.</p>'
     expect(slateToHtml(slate, { ...slateToDomConfig, convertLineBreakToBr: true })).toEqual(html)
   })
+
+  it('does not insert a br tag after an inline element', () => {
+    const slate: any[] = [
+      {
+        type: 'div',
+        style: { padding: '10px' },
+        children: [
+          {
+            type: 'link',
+            children: [{ text: 'Mojo Nomad' }],
+          },
+          {
+            text: ' was born from a desire to create',
+          },
+        ],
+      },
+    ]
+    const html = '<a href>Mojo Nomad</a> was born from a desire to create'
+    expect(slateToHtml(slate, { ...slateToDomConfig, convertLineBreakToBr: true })).toEqual(html)
+  })
 })

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -2,22 +2,23 @@ import { jsx } from 'slate-hyperscript'
 import { parseDocument, Parser, ElementType } from 'htmlparser2'
 import { ChildNode, DomHandler, Element, isTag, Node } from 'domhandler'
 import { getChildren, getName, replaceElement, textContent } from 'domutils'
-import { Context, getContext, isAllWhitespace, processTextValue } from './whitespace'
+import { selectAll } from 'css-select'
 
 import { Config } from '../../config/htmlToSlate/types'
 import { config as defaultConfig } from '../../config/htmlToSlate/default'
 
-import { selectOne, selectAll } from 'css-select'
-import serializer from 'dom-serializer'
 import { extractCssFromStyle } from '../../utilities/domhandler'
 import { getNested } from '../../utilities'
+import { isBlock } from '../blocks'
+
+import { Context, getContext, isAllWhitespace, processTextValue } from './whitespace'
 
 interface Ideserialize {
   el: ChildNode
   config?: Config
   index?: number
   childrenLength?: number
-  context?: string
+  context?: Context
 }
 
 const deserialize = ({
@@ -83,6 +84,7 @@ const deserialize = ({
       context: childrenContext as Context,
       isInlineStart: index === 0,
       isInlineEnd: Number.isInteger(childrenLength) && index === childrenLength - 1,
+      isNextSiblingBlock: (el.next && isTag(el.next) && isBlock(el.next.tagName)) || false,
     })
     if ((config.filterWhitespaceNodes && isAllWhitespace(text) && !childrenContext) || text === '') {
       return null

--- a/src/serializers/htmlToSlate/whitespace.ts
+++ b/src/serializers/htmlToSlate/whitespace.ts
@@ -7,6 +7,7 @@ interface IprocessTextValue {
   context?: Context
   isInlineStart?: boolean
   isInlineEnd?: boolean
+  isNextSiblingBlock?: boolean
 }
 
 export const processTextValue = ({
@@ -14,6 +15,7 @@ export const processTextValue = ({
   context = '',
   isInlineStart = false,
   isInlineEnd = false,
+  isNextSiblingBlock = false,
 }: IprocessTextValue): string => {
   let parsed = text
   if (context === 'preserve') {
@@ -26,7 +28,7 @@ export const processTextValue = ({
       parsed = parsed.trimStart()
     }
     // is this the end of inline content in a block element?
-    if (isInlineEnd) {
+    if (isInlineEnd || isNextSiblingBlock) {
       parsed = parsed.trimEnd()
     }
   }

--- a/src/serializers/slatetoHtml/index.ts
+++ b/src/serializers/slatetoHtml/index.ts
@@ -25,7 +25,7 @@ export const slateToDom: SlateToDom = (node: any[], config = defaultConfig) => {
   return document
 }
 
-const slateNodeToHtml = (node: any, config = defaultConfig, isLastNode = false) => {
+const slateNodeToHtml = (node: any, config = defaultConfig, isLastNodeInDocument = false) => {
   if (SlateText.isText(node)) {
     const str = node.text
 
@@ -102,14 +102,13 @@ const slateNodeToHtml = (node: any, config = defaultConfig, isLastNode = false) 
   }
 
   if (element) {
-    if (!isBlock(element.name) && config.convertLineBreakToBr && !isLastNode) {
-      return new Document([element, new Element('br', {})])
-    }
     return element
   }
 
-  if (config.convertLineBreakToBr && !isLastNode) {
+  // add line break between inline nodes
+  if (config.convertLineBreakToBr && !isLastNodeInDocument) {
     children.push(new Element('br', {}))
   }
+
   return new Document(children)
 }


### PR DESCRIPTION
Several changes in this commit

- Added `isNextSiblingBlock` as a way to determine whether whitespace needs to be trimmed in the text before the next block element ([see updated fixture](https://github.com/thompsonsj/slate-serializers/pull/38/files#diff-b8c31d1cd177f2fdc6a6d4c856f9e1fe5501def07d3a5a2651f26eeb7a63252eR136) example)
- Added `htmlFromSlate` as an addition to `html` in unit tests, since the slate-to-html conversion is not necessarily leads to the same `html` (because of whitespace collapse)
- Fixed wrong `<br>` insertion after inline elements
- Prevent adding line break when within `<br>`  is happen to be within text nodes