### PR TITLE
fix(src): folder capitalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ const slate = [
 const serializedToHtml = slateToHtml(slate, payloadSlateToDomConfig)
 ```
 
-You can create your own configuration file that implements your schema. See [src/config/slatetoDom/payload.ts](src/config/slatetoDom/payload.ts) for an example of how to extend the default configuration or copy [src/config/slatetoDom/default.ts](src/config/slatetoDom/default.ts) and rewrite it as appropriate.
+You can create your own configuration file that implements your schema. See [src/config/slateToDom/payload.ts](src/config/slateToDom/payload.ts) for an example of how to extend the default configuration or copy [src/config/slateToDom/default.ts](src/config/slateToDom/default.ts) and rewrite it as appropriate.
 
 ### htmlToSlate
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -72,7 +72,7 @@ For text nodes inside `<code>` and/or `<pre>` HTML elements, whitespace is prese
 
 The Slate configuration for Payload CMS results in some Slate nodes being stored with an undefined `type`. See https://github.com/payloadcms/payload/discussions/1141#discussioncomment-4255845.
 
-Note the `defaultTag` option that is passed in the [Payload CMS configuration for `slateToHtml`/`slateToDom`](](src/config/slatetoDom/payload.ts)). This creates a `<p>` HTML element tag whenever a Slate node has an undefined `type`. This is consistent with the approach taken by Payload CMS: In the docs for the rich text field, the serializer example renders the `<p>` HTML element as the default - i.e. if no types are found. See https://github.com/payloadcms/payload/blob/master/docs/fields/rich-text.mdx.
+Note the `defaultTag` option that is passed in the [Payload CMS configuration for `slateToHtml`/`slateToDom`](](src/config/slateToDom/payload.ts)). This creates a `<p>` HTML element tag whenever a Slate node has an undefined `type`. This is consistent with the approach taken by Payload CMS: In the docs for the rich text field, the serializer example renders the `<p>` HTML element as the default - i.e. if no types are found. See https://github.com/payloadcms/payload/blob/master/docs/fields/rich-text.mdx.
 
 At the moment, we cannot convert from `slateToHtml` to `htmlToSlate` and vice versa and expect consistent results. This is because, with the Payload conifguration, `slateToHtml` adds p tags, and then `htmlToSlate` adds these `p` tags into the Slate JSON.
 
@@ -82,7 +82,7 @@ May be able to resolve the above by simply removing `p` tag conversion? Could po
 
 One of the tricker parts of serializing from between Slate and HTML is that Slate doesn't care about HTML entity encoding. This is expected - Slate is unaware of HTML, it offers a serializer friendly format.
 
-Special considerations are made for `htmlToSlate` and `slatetoHtml`.
+Special considerations are made for `htmlToSlate` and `slateToHtml`.
 
 ### `slateToHtml`
 

--- a/src/config/slateToDom/default.ts
+++ b/src/config/slateToDom/default.ts
@@ -1,0 +1,56 @@
+import { Element } from 'domhandler'
+import { Config } from './types'
+
+// Map Slate element names to HTML tag names
+// Staightforward transform - no attributes are considered
+// Use transforms instead for more complex operations
+const ELEMENT_NAME_TAG_MAP = {
+  p: 'p',
+  paragraph: 'p',
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
+  h5: 'h5',
+  h6: 'h6',
+  ul: 'ul',
+  ol: 'ol',
+  li: 'li',
+  blockquote: 'blockquote',
+}
+
+const MARK_ELEMENT_TAG_MAP = {
+  strikethrough: ['s'],
+  bold: ['strong'],
+  underline: ['u'],
+  italic: ['i'],
+  code: ['pre', 'code'],
+}
+
+export const config: Config = {
+  markMap: MARK_ELEMENT_TAG_MAP,
+  elementMap: ELEMENT_NAME_TAG_MAP,
+  elementTransforms: {
+    quote: ({ children = [] }) => {
+      const p = [new Element('p', {}, children)]
+      return new Element('blockquote', {}, p)
+    },
+    link: ({ node, children = [] }) => {
+      const attrs: any = {}
+      if (node.newTab) {
+        attrs.target = '_blank'
+      }
+      return new Element(
+        'a',
+        {
+          href: node.url,
+          ...attrs,
+        },
+        children,
+      )
+    },
+  },
+  encodeEntities: true,
+  alwaysEncodeCodeEntities: false,
+  convertLineBreakToBr: false,
+}

--- a/src/config/slateToDom/payload.ts
+++ b/src/config/slateToDom/payload.ts
@@ -1,0 +1,34 @@
+import { Element } from 'domhandler'
+import { config as defaultConfig } from './default'
+import { SlateToDomConfig } from '../..'
+
+/**
+ * Configuration for Payload CMS
+ *
+ * Tested for v1.1.21
+ */
+
+export const config: SlateToDomConfig = {
+  ...defaultConfig,
+  elementTransforms: {
+    ...defaultConfig.elementTransforms,
+    link: ({ node, children = [] }) => {
+      const attrs: any = {}
+      if (node.linkType) {
+        attrs['data-link-type'] = node.linkType
+      }
+      if (node.newTab) {
+        attrs.target = '_blank'
+      }
+      return new Element(
+        'a',
+        {
+          href: node.url,
+          ...attrs,
+        },
+        children,
+      )
+    },
+  },
+  defaultTag: 'p',
+}

--- a/src/config/slateToDom/slateDemo.ts
+++ b/src/config/slateToDom/slateDemo.ts
@@ -1,0 +1,29 @@
+import { Config } from './types'
+
+const ELEMENT_NAME_TAG_MAP = {
+  ['block-quote']: 'blockquote',
+  ['heading-one']: 'h1',
+  ['heading-two']: 'h2',
+  ['list-item']: 'li',
+  ['numbered-list']: 'ol',
+  ['bulleted-list']: 'ul',
+  paragraph: 'p',
+}
+
+const MARK_ELEMENT_TAG_MAP = {
+  strikethrough: ['s'],
+  bold: ['strong'],
+  underline: ['u'],
+  italic: ['i'],
+  code: ['pre', 'code'],
+}
+
+export const config: Config = {
+  markMap: MARK_ELEMENT_TAG_MAP,
+  elementMap: ELEMENT_NAME_TAG_MAP,
+  elementStyleMap: {
+    align: 'textAlign',
+  },
+  elementTransforms: {},
+  encodeEntities: true,
+}

--- a/src/config/slateToDom/types.ts
+++ b/src/config/slateToDom/types.ts
@@ -1,0 +1,26 @@
+import { ChildNode, Element } from 'domhandler'
+
+interface ElementTagTransform {
+  [key: string]: ({
+    node,
+    attribs,
+    children,
+  }: {
+    node?: any
+    attribs?: { [key: string]: string }
+    children?: ChildNode[]
+  }) => Element
+}
+
+export interface Config {
+  markMap: { [key: string]: string[] }
+  elementMap: { [key: string]: string }
+  elementStyleMap?: {
+    [key: string]: string
+  }
+  elementTransforms: ElementTagTransform
+  defaultTag?: string
+  encodeEntities?: boolean
+  alwaysEncodeCodeEntities?: boolean
+  convertLineBreakToBr?: boolean
+}

--- a/src/serializers/slateToHtml/index.ts
+++ b/src/serializers/slateToHtml/index.ts
@@ -1,0 +1,114 @@
+import { AnyNode, Document, Element, isTag, Text } from 'domhandler'
+import serializer from 'dom-serializer'
+import { getName } from 'domutils'
+import { encode } from 'html-entities'
+import { Text as SlateText } from 'slate'
+
+import { config as defaultConfig } from '../../config/slateToDom/default'
+import { nestedMarkElements } from '../../utilities/domhandler'
+import { getNested, isEmptyObject, styleToString } from '../../utilities'
+import { SlateToDomConfig } from '../..'
+import { isBlock } from '../blocks'
+
+type SlateToHtml = (node: any[], config?: SlateToDomConfig) => string
+type SlateToDom = (node: any[], config?: SlateToDomConfig) => AnyNode | ArrayLike<AnyNode>
+
+export const slateToHtml: SlateToHtml = (node: any[], config = defaultConfig) => {
+  const document = slateToDom(node, config)
+  return serializer(document, {
+    encodeEntities: 'encodeEntities' in config ? config.encodeEntities : false,
+  })
+}
+
+export const slateToDom: SlateToDom = (node: any[], config = defaultConfig) => {
+  const document = node.map((n, index) => slateNodeToHtml(n, config, index === node.length - 1))
+  return document
+}
+
+const slateNodeToHtml = (node: any, config = defaultConfig, isLastNodeInDocument = false) => {
+  if (SlateText.isText(node)) {
+    const str = node.text
+
+    // convert line breaks to br tags
+    const strLines = config.convertLineBreakToBr ? str.split('\n') : [str]
+    const textChildren: (Element | Text)[] = []
+
+    strLines.forEach((line, index) => {
+      const markElements: string[] = []
+      Object.keys(config.markMap).forEach((key) => {
+        if ((node as any)[key]) {
+          markElements.push(...config.markMap[key])
+        }
+      })
+      // clone markElements (it gets modified)
+      const markElementsClone = [...markElements]
+      const textElement = nestedMarkElements(markElements, new Text(line))
+      if (
+        config.alwaysEncodeCodeEntities &&
+        config.encodeEntities === false &&
+        isTag(textElement) &&
+        getName(textElement) === 'pre'
+      ) {
+        textChildren.push(nestedMarkElements(markElementsClone, new Text(encode(line))))
+      } else {
+        textChildren.push(textElement)
+      }
+
+      if (index < strLines.length - 1) {
+        textChildren.push(new Element('br', {}))
+      }
+    })
+
+    return new Document(textChildren)
+  }
+
+  const children: any[] = node.children ? node.children.map((n: any[]) => slateNodeToHtml(n, config)) : []
+
+  let attribs: { [key: string]: string } = {}
+  const styleAttrs: { [key: string]: string } = {}
+  const style = getNested(config, 'elementStyleMap')
+  if (style) {
+    Object.keys(style).forEach((slateKey) => {
+      const cssProperty = style[slateKey]
+      const cssValue = node[slateKey]
+      if (cssValue) {
+        styleAttrs[cssProperty] = cssValue
+      }
+    })
+
+    if (!isEmptyObject(styleAttrs)) {
+      attribs = {
+        ...attribs,
+        style: styleToString(styleAttrs),
+      }
+    }
+  }
+
+  let element: Element | null = null
+
+  // more complex transforms
+  if (config.elementTransforms[node.type]) {
+    element = config.elementTransforms[node.type]({ node, attribs, children })
+  }
+
+  // straightforward node to element
+  if (!element && config.elementMap[node.type]) {
+    element = new Element(config.elementMap[node.type], attribs, children)
+  }
+
+  // default tag
+  if (!element && config.defaultTag && !node.type) {
+    element = new Element(config.defaultTag, {}, children)
+  }
+
+  if (element) {
+    return element
+  }
+
+  // add line break between inline nodes
+  if (config.convertLineBreakToBr && !isLastNodeInDocument) {
+    children.push(new Element('br', {}))
+  }
+
+  return new Document(children)
+}


### PR DESCRIPTION
Fixes https://github.com/thompsonsj/slate-serializers/issues/46.

Issue caused by working in a case insensitive environment. This has broken `slateToHtml` imports from version `0.0.27` installed as a node module. The path was changed in https://github.com/thompsonsj/slate-serializers/pull/40 to use the same capitalisation as the folder, but the folder name still had the incorrect capitalisation in the git repository.

See https://stackoverflow.com/questions/3011625/git-mv-and-only-change-case-of-directory