### PR TITLE
Improved <br> conversion

### DIFF
--- a/__tests__/serializers/htmlToSlate/index.spec.ts
+++ b/__tests__/serializers/htmlToSlate/index.spec.ts
@@ -404,6 +404,32 @@ describe('empty content', () => {
         }),
       ).toEqual(slate)
     })
+
+    it('adds a line break in place of a br tag inside of a block element', () => {
+      const html = '<p>Line 1<br>\n<span>Line 2</span></p>'
+      const slate: any[] = [
+        {
+          type: 'p',
+          children: [
+            {
+              text: 'Line 1',
+            },
+            {
+              text: '\n',
+            },
+            {
+              text: 'Line 2',
+            },
+          ],
+        },
+      ]
+      expect(
+        htmlToSlate(html, {
+          ...htmlToSlateConfig,
+          convertBrToLineBreak: true,
+        }),
+      ).toEqual(slate)
+    })
   })
 })
 

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -44,8 +44,7 @@ const deserialize = ({
   )
 
   if (nodeName === 'br' && config.convertBrToLineBreak && context !== 'preserve') {
-    let lineBreak = context ? '\n' : ''
-    return [jsx('text', { text: lineBreak }, [])]
+    return [jsx('text', { text: context ? '\n' : '' }, [])]
   }
 
   const children = currentEl.childNodes

--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -88,6 +88,7 @@ const deserialize = ({
       isInlineStart: index === 0,
       isInlineEnd: Number.isInteger(childrenLength) && isLastChild,
       isNextSiblingBlock: (el.next && isTag(el.next) && isBlock(el.next.tagName)) || false,
+      isNextSiblingBlock: (el.next && isTag(el.next) && isBlock(el.next.tagName)) || false,
     })
     if ((config.filterWhitespaceNodes && isAllWhitespace(text) && !childrenContext) || text === '') {
       return null


### PR DESCRIPTION
Changes:
- Added a unit test for `<p>Line 1<br>\n<span>Line 2</span></p>` conversion
- Renamed `parent` to `currentEl` within `deserialize` function since that name was confusing
- Added stripping of empty space before and after `<br>`

There'll probably be more changes if issues arise.