### PR TITLE
feat(slatetohtml): mark transforms

### DIFF
--- a/__tests__/serializers/slateToHtml/index.spec.ts
+++ b/__tests__/serializers/slateToHtml/index.spec.ts
@@ -154,8 +154,10 @@ describe('slateToHtml expected behaviour', () => {
       html,
     )
   })
+})
 
-  it('process a custom element tag map', () => {
+describe('custom config', () => {
+  it('process an element tag map', () => {
     const html = '<p>Paragraph</p><img src="https://picsum.photos/id/237/200/300">'
     const slate = [
       {
@@ -181,6 +183,29 @@ describe('slateToHtml expected behaviour', () => {
           })
         },
       },
+    }
+    expect(slateToHtml(slate, config)).toEqual(html)
+  })
+
+  it('map Slate attribute to inline style from element style map', () => {
+    const html = '<p style="font-size:96px;"><strong>Paragraph</strong></p>'
+    const slate = [
+      {
+        type: 'p',
+        fontSize: '96px',
+        children: [
+          {
+            bold: true,
+            text: 'Paragraph',
+          },
+        ],
+      }
+    ]
+    const config = {
+      ...slateToDomConfig,
+      elementStyleMap: {
+        fontSize: 'font-size',
+      }
     }
     expect(slateToHtml(slate, config)).toEqual(html)
   })

--- a/__tests__/utilities/domhandler.spec.ts
+++ b/__tests__/utilities/domhandler.spec.ts
@@ -1,3 +1,4 @@
+import { Element } from "domhandler"
 import { nestedMarkElementsString } from '../../src/utilities/domhandler'
 
 /**
@@ -6,13 +7,13 @@ import { nestedMarkElementsString } from '../../src/utilities/domhandler'
 
 describe('nestedMarkElementsString', () => {
   it('nests text in 1 mark element', () => {
-    expect(nestedMarkElementsString(['u'], 'Unarticulated Annotation text')).toEqual(
+    expect(nestedMarkElementsString([new Element('u', {})], 'Unarticulated Annotation text')).toEqual(
       '<u>Unarticulated Annotation text</u>',
     )
   })
 
   it('nests text in 2 mark elements', () => {
-    expect(nestedMarkElementsString(['u', 'i'], 'Unarticulated Annotation, and Idiomatic Text text')).toEqual(
+    expect(nestedMarkElementsString([new Element('u', {}), new Element('i', {})], 'Unarticulated Annotation, and Idiomatic Text text')).toEqual(
       '<u><i>Unarticulated Annotation, and Idiomatic Text text</i></u>',
     )
   })
@@ -20,7 +21,7 @@ describe('nestedMarkElementsString', () => {
   it('nests text in 3 mark elements', () => {
     expect(
       nestedMarkElementsString(
-        ['u', 'i', 'strong'],
+        [new Element('u', {}), new Element('i', {}), new Element('strong', {})],
         'Strong Importance, Unarticulated Annotation, and Idiomatic Text text',
       ),
     ).toEqual('<u><i><strong>Strong Importance, Unarticulated Annotation, and Idiomatic Text text</strong></i></u>')
@@ -29,7 +30,7 @@ describe('nestedMarkElementsString', () => {
   it('nests text in 4 mark elements', () => {
     expect(
       nestedMarkElementsString(
-        ['u', 'i', 'strong', 's'],
+        [new Element('u', {}), new Element('i', {}), new Element('strong', {}), new Element('s', {})],
         'Strong Importance, Unarticulated Annotation, Idiomatic Text and Strikethrough text',
       ),
     ).toEqual(

--- a/docs/config/slateToDom.md
+++ b/docs/config/slateToDom.md
@@ -1,0 +1,89 @@
+# slateToDom configuration
+
+## elementMap
+
+Describe how Slate JSON **node types** are mapped to HTML element tags.
+
+In the following simple example, Slate JSON nodes with a `type` of `heading-one` are mapped to `h1` HTML elements.
+
+```ts
+import { SlateToDomConfig } from 'slate-serializers'
+
+const config: SlateToDomConfig = {
+  // ...
+  elementMap: {
+    ['heading-one']: 'h1'
+  }
+  // ...
+}
+```
+
+## elementTransforms
+
+For more complex transformations, use `elementTransforms`.
+
+```ts
+import { Element } from "domhandler"
+
+const config: SlateToDomConfig = {
+  // ...
+  elementTransforms: {
+    image: ({ node }: { node?: any }) => {
+      return new Element('img', {
+        src: node.url,
+      })
+    },
+  }
+  // ...
+}
+```
+
+The Slate JS node is passed into this function. A node of type `Element` from `domhandler` must be returned. Combine this with [utilities from `domutils`](https://domutils.js.org/) to perform further manipulation.
+
+In this case, the `src` attribute is set using a `url` value on the Slate JS node.
+
+## markMap
+
+Describe how Slate JSON **node attributes** are mapped to HTML formatting elements.
+
+In the following simple example, Slate JSON nodes with an attribute of `subScript: true` include a `sub` HTML formatting element.
+
+```ts
+import { SlateToDomConfig } from 'slate-serializers'
+
+const config: SlateToDomConfig = {
+  // ...
+  markMap: {
+    subScript: ['sub']
+  }
+  // ...
+}
+```
+
+Note that the config value is an array of strings. This allows multiple formatting elements to be mapped to a single Slate JSON node attribute.
+
+## markTransforms
+
+For more complex transformations, use `markTransforms`.
+
+```ts
+import { Element } from "domhandler"
+
+const config: SlateToDomConfig = {
+  // ...
+  markTransforms: {
+    strong: ({ node }: { node?: any }) => {
+      return new Element('strong', {
+        style: `font-size:${node.fontSize};`,
+      })
+    },
+  }
+  // ...
+}
+```
+
+**Keys should map to the HTML formatting element tag name**. This is different to `elementTransform` which use the value of the Slate JSON `type` property. Multiple nested formatting elements can be generated from a Slate JSON value, and we want to be able to control which HTML formatting tag elements inherit those attributes.
+
+The Slate JS node is passed into this function. A node of type `Element` from `domhandler` must be returned. Combine this with [utilities from `domutils`](https://domutils.js.org/) to perform further manipulation.
+
+In this case, the `style` attribute is set with a CSS string using a `fontSize` value on the Slate JS node.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "domutils": "^3.1.0",
         "html-entities": "^2.3.3",
         "htmlparser2": "~7.2.0",
+        "postcss": "^8.4.24",
         "slate": "^0.94.1",
         "slate-hyperscript": "^0.77.0"
       },
@@ -26,6 +27,7 @@
         "commitizen": "^4.3.0",
         "husky": "^8.0.3",
         "jest": "^29.5.0",
+        "postcss-js": "^4.0.1",
         "prettier": "^2.8.8",
         "ts-jest": "^29.1.0",
         "tslint": "^6.1.3",
@@ -2474,6 +2476,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/camelcase-keys": {
@@ -6199,6 +6210,23 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6513,8 +6541,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -6599,6 +6626,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+      "dev": true,
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
       }
     },
     "node_modules/prettier": {
@@ -7091,6 +7164,14 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9745,6 +9826,12 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
       "dev": true
     },
     "camelcase-keys": {
@@ -12496,6 +12583,11 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -12725,8 +12817,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -12786,6 +12877,25 @@
             "p-limit": "^2.2.0"
           }
         }
+      }
+    },
+    "postcss": {
+      "version": "8.4.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "requires": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "postcss-js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+      "dev": true,
+      "requires": {
+        "camelcase-css": "^2.0.1"
       }
     },
     "prettier": {
@@ -13139,6 +13249,11 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-support": {
       "version": "0.5.13",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "commitizen": "^4.3.0",
     "husky": "^8.0.3",
     "jest": "^29.5.0",
+    "postcss-js": "^4.0.1",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.0",
     "tslint": "^6.1.3",
@@ -52,6 +53,7 @@
     "domutils": "^3.1.0",
     "html-entities": "^2.3.3",
     "htmlparser2": "~7.2.0",
+    "postcss": "^8.4.24",
     "slate": "^0.94.1",
     "slate-hyperscript": "^0.77.0"
   }

--- a/src/config/slateToDom/types.ts
+++ b/src/config/slateToDom/types.ts
@@ -18,6 +18,9 @@ export interface Config {
   elementStyleMap?: {
     [key: string]: string
   }
+  markStyleMap?: {
+    [key: string]: string
+  }
   elementTransforms: ElementTagTransform
   defaultTag?: string
   encodeEntities?: boolean

--- a/src/config/slateToDom/types.ts
+++ b/src/config/slateToDom/types.ts
@@ -1,5 +1,15 @@
 import { ChildNode, Element } from 'domhandler'
 
+interface MarkTagTransform {
+  [key: string]: ({
+    node,
+    attribs,
+  }: {
+    node?: any
+    attribs?: { [key: string]: string }
+  }) => Element
+}
+
 interface ElementTagTransform {
   [key: string]: ({
     node,
@@ -21,6 +31,7 @@ export interface Config {
   markStyleMap?: {
     [key: string]: string
   }
+  markTransforms?: MarkTagTransform
   elementTransforms: ElementTagTransform
   defaultTag?: string
   encodeEntities?: boolean

--- a/src/serializers/slateToHtml/index.ts
+++ b/src/serializers/slateToHtml/index.ts
@@ -41,17 +41,16 @@ const slateNodeToHtml = (node: any, config = defaultConfig, isLastNodeInDocument
     strLines.forEach((line, index) => {
       const markElements: Element[] = []
 
-/**
-Object.keys(config.markMap).forEach((key) => {
-        if ((node as any)[key]) {
-          markElements.push(...config.markMap[key])
-        }
-      })
- */
-
       Object.keys(config.markMap).forEach((key) => {
         if ((node as any)[key]) {
-          const elements = config.markMap[key].map((tagName) => new Element(tagName, {}, []))
+          const elements: Element[] = config.markMap[key]
+            .map((tagName) => {
+              // more complex transforms
+              if (config.markTransforms?.[tagName]) {
+                return config.markTransforms[tagName]({ node, attribs: {} })
+              }
+              return new Element(tagName, {}, [])
+            })
           markElements.push(...elements)
         }
       })

--- a/src/serializers/slateToHtml/index.ts
+++ b/src/serializers/slateToHtml/index.ts
@@ -8,7 +8,6 @@ import { config as defaultConfig } from '../../config/slateToDom/default'
 import { nestedMarkElements } from '../../utilities/domhandler'
 import { getNested, isEmptyObject, styleToString, encodeBreakingEntities } from '../../utilities'
 import { SlateToDomConfig } from '../..'
-import { isBlock } from '../blocks'
 
 type SlateToHtml = (node: any[], config?: SlateToDomConfig) => string
 type SlateToDom = (node: any[], config?: SlateToDomConfig) => AnyNode | ArrayLike<AnyNode>
@@ -40,10 +39,20 @@ const slateNodeToHtml = (node: any, config = defaultConfig, isLastNodeInDocument
     const textChildren: (Element | Text)[] = []
 
     strLines.forEach((line, index) => {
-      const markElements: string[] = []
-      Object.keys(config.markMap).forEach((key) => {
+      const markElements: Element[] = []
+
+/**
+Object.keys(config.markMap).forEach((key) => {
         if ((node as any)[key]) {
           markElements.push(...config.markMap[key])
+        }
+      })
+ */
+
+      Object.keys(config.markMap).forEach((key) => {
+        if ((node as any)[key]) {
+          const elements = config.markMap[key].map((tagName) => new Element(tagName, {}, []))
+          markElements.push(...elements)
         }
       })
       // clone markElements (it gets modified)
@@ -81,7 +90,6 @@ const slateNodeToHtml = (node: any, config = defaultConfig, isLastNodeInDocument
         styleAttrs[cssProperty] = cssValue
       }
     })
-
     if (!isEmptyObject(styleAttrs)) {
       attribs = {
         ...attribs,

--- a/src/utilities/domhandler.ts
+++ b/src/utilities/domhandler.ts
@@ -11,36 +11,59 @@ import { parseStyleCssText } from '.'
  * elements. Really shouldn't be any more than that!
  */
 
-export const nestedMarkElementsString = (els: string[], text: string) => {
+export const nestedMarkElementsString = (els: Element[], text: string) => {
   return serializer(nestedMarkElements(els, new Text(text)))
 }
 
-export const nestedMarkElements = (els: string[], element: Element | Text) => {
+/**
+const el1 = els.pop()
+  element = new Element(el1 as string, {}, [element])
+  if (!els || els.length === 0) {
+    return element
+  } 
+ */
+
+export const nestedMarkElements = (els: Element[], element: Element | Text) => {
   if (els.length === 0) {
     return element
   }
   const el1 = els.pop()
-  element = new Element(el1 as string, {}, [element])
+  if (el1) {
+    el1.children = [element]
+    element = el1
+  }
   if (!els || els.length === 0) {
     return element
   }
   const el2 = els.pop()
-  element = new Element(el2 as string, {}, [element])
+  if (el2) {
+    el2.children = [element]
+    element = el2
+  }
   if (!els || els.length === 0) {
     return element
   }
   const el3 = els.pop()
-  element = new Element(el3 as string, {}, [element])
+  if (el3) {
+    el3.children = [element]
+    element = el3
+  }
   if (!els || els.length === 0) {
     return element
   }
   const el4 = els.pop()
-  element = new Element(el4 as string, {}, [element])
+  if (el4) {
+    el4.children = [element]
+    element = el4
+  }
   if (!els || els.length === 0) {
     return element
   }
   const el5 = els.pop()
-  element = new Element(el5 as string, {}, [element])
+  if (el5) {
+    el5.children = [element]
+    element = el5
+  }
   if (!els || els.length === 0) {
     return element
   }

--- a/src/utilities/domhandler.ts
+++ b/src/utilities/domhandler.ts
@@ -15,14 +15,6 @@ export const nestedMarkElementsString = (els: Element[], text: string) => {
   return serializer(nestedMarkElements(els, new Text(text)))
 }
 
-/**
-const el1 = els.pop()
-  element = new Element(el1 as string, {}, [element])
-  if (!els || els.length === 0) {
-    return element
-  } 
- */
-
 export const nestedMarkElements = (els: Element[], element: Element | Text) => {
   if (els.length === 0) {
     return element


### PR DESCRIPTION
Add a `markTransforms` config option to the `slateToDomConfig`.

## Details

Documentation and tests included in the pull request.

## Background

https://github.com/thompsonsj/slate-serializers/issues/59 describes an issue where inline styles are not included in the resulting HTML for `slateToHtml`.

Examining the issue, it seems that Slate is set up in such a way that it is adding additional properties to individual child nodes if a `p` type.

e.g.

```ts
[
  {
    type: 'p',
    children: [
      {
        bold: true,
        style: {
          fontSize: '96px',
          }
        },
        text: 'Paragraph',
      },
    ],
  }
]
```

This suggests that attributes are being set on HTML formatting elements. In this case, we should expect (assuming the appropriate configuration has been added to support a style object): `<p><strong style="font-size: 96px;">Paragraph</strong></p>`;

This is a job for transform functions. Currently, transform functions are only supported on elements (not mark/formatting elements such as `strong`).

If the style object was set on the `p` type, it would be fine - we could do the following with an appropriate `elementTransform`:

```ts
[
  {
    type: 'p',
    style: {
      fontSize: '96px',
    },
    children: [
      {
        bold: true,
        text: 'Paragraph',
      },
    ],
  }
]

// <p style="font-size: 96px;"><strong>Paragraph</strong></p>
```

This pull request adds mark transforms that permit the same kind of transforms on mark/formatting elements such as `strong`. I see no reason why that should not be supported - it is valid to add attributes on this kind of element.

A comprehensive test suite and documentation is included to demonstrate how this works.