### PR TITLE
refactor(slatetodom)!: apply markTransforms on Slate JSON properties

### DIFF
--- a/__tests__/serializers/slateToHtml/index.spec.ts
+++ b/__tests__/serializers/slateToHtml/index.spec.ts
@@ -257,7 +257,7 @@ describe('custom config', () => {
   })
 
   it('processes a mark transform', () => {
-    const html = '<p><strong style="font-size:96px;">Paragraph</strong></p>'
+    const html = '<p><span style=\"font-size:96px;\"><strong>Paragraph</strong></span></p>'
     const slate = [
       {
         type: 'p',
@@ -274,9 +274,44 @@ describe('custom config', () => {
       ...slateToDomConfig,
       markTransforms: {
         ...slateToDomConfig.markTransforms,
-        strong: ({ node }: { node?: any }) => {
-          return new Element('strong', {
+        fontSize: ({ node }: { node?: any }) => {
+          return new Element('span', {
             style: `font-size:${node.fontSize};`,
+          })
+        },
+      },
+    }
+    expect(slateToHtml(slate, config)).toEqual(html)
+  })
+
+  it('demo for issue #59', () => {
+    const html = '<p><span style=\"font-size:20px;\"><strong><sub>Paragraph</sub></strong></span></p>'
+    const slate = [
+      {
+        type: 'p',
+        children: [
+          {
+            bold: true,
+            style: {
+              fontSize: '20px',
+            },
+            subscript: true,
+            text: 'Paragraph',
+          },
+        ],
+      }
+    ]
+    const config = {
+      ...slateToDomConfig,
+      markMap: {
+        ...slateToDomConfig.markMap,
+        subscript: ['sub']
+      },
+      markTransforms: {
+        ...slateToDomConfig.markTransforms,
+        style: ({ node }: { node?: any }) => {
+          return new Element('span', {
+            ...(node.style?.fontSize && {style: `font-size:${node.style.fontSize};`}),
           })
         },
       },
@@ -330,7 +365,7 @@ describe('style attribute css transforms with postcss', () => {
   })
 
   it('mark transforms', () => {
-    const html = '<p><strong style="font-size: 96px; --text-color: #DD3A0A; @media screen { z-index: 1; color: var(--text-color) }">Paragraph</strong></p>'
+    const html = '<p><span style=\"font-size: 96px; --text-color: #DD3A0A; @media screen { z-index: 1; color: var(--text-color) }\"><strong>Paragraph</strong></span></p>'
     const slate = [
       {
         type: 'p',
@@ -354,8 +389,8 @@ describe('style attribute css transforms with postcss', () => {
       ...slateToDomConfig,
       markTransforms: {
         ...slateToDomConfig.markTransforms,
-        strong: ({ node }: { node?: any }) => {
-          return new Element('strong', {
+        style: ({ node }: { node?: any }) => {
+          return new Element('span', {
             style: transformStyleObjectToString(node.style),
           })
         },
@@ -366,7 +401,7 @@ describe('style attribute css transforms with postcss', () => {
 
   it('mark transforms on multiple marks', () => {
     const html =
-      '<p>This is editable <strong style=\"font-size: 20px; font-weight: 600; text-decoration: underline dotted\">rich</strong> text, <i style=\"text-decoration: underline\">much</i> better than a <pre><code style=\"color: red\">&lt;textarea&gt;</code></pre>!</p>'
+      '<p>This is editable <span style=\"font-size: 20px; font-weight: 600; text-decoration: underline dotted\"><strong>rich</strong></span> text, <span style=\"text-decoration: underline\"><i>much</i></span> better than a <span style=\"color: red\"><pre><code>&lt;textarea&gt;</code></pre></span>!</p>'
     const slate = [
       {
         type: 'p',
@@ -413,18 +448,8 @@ describe('style attribute css transforms with postcss', () => {
       ...slateToDomConfig,
       markTransforms: {
         ...slateToDomConfig.markTransforms,
-        code: ({ node }: { node?: any }) => {
-          return new Element('code', {
-            style: transformStyleObjectToString(node.style),
-          })
-        },
-        i: ({ node }: { node?: any }) => {
-          return new Element('i', {
-            style: transformStyleObjectToString(node.style),
-          })
-        },
-        strong: ({ node }: { node?: any }) => {
-          return new Element('strong', {
+        style: ({ node }: { node?: any }) => {
+          return new Element('span', {
             style: transformStyleObjectToString(node.style),
           })
         },

--- a/docs/config/slateToDom.md
+++ b/docs/config/slateToDom.md
@@ -72,8 +72,8 @@ import { Element } from "domhandler"
 const config: SlateToDomConfig = {
   // ...
   markTransforms: {
-    strong: ({ node }: { node?: any }) => {
-      return new Element('strong', {
+    fontSize: ({ node }: { node?: any }) => {
+      return new Element('span', {
         style: `font-size:${node.fontSize};`,
       })
     },
@@ -82,7 +82,7 @@ const config: SlateToDomConfig = {
 }
 ```
 
-**Keys should map to the HTML formatting element tag name**. This is different to `elementTransform` which use the value of the Slate JSON `type` property. Multiple nested formatting elements can be generated from a Slate JSON value, and we want to be able to control which HTML formatting tag elements inherit those attributes.
+**Keys should map keys on the Slate object**. This is different to `elementTransform` which uses the value of the Slate JSON `type` property only.
 
 The Slate JS node is passed into this function. A node of type `Element` from `domhandler` must be returned. Combine this with [utilities from `domutils`](https://domutils.js.org/) to perform further manipulation.
 

--- a/src/serializers/slateToHtml/index.ts
+++ b/src/serializers/slateToHtml/index.ts
@@ -6,7 +6,7 @@ import { Text as SlateText } from 'slate'
 
 import { config as defaultConfig } from '../../config/slateToDom/default'
 import { nestedMarkElements } from '../../utilities/domhandler'
-import { getNested, isEmptyObject, styleToString, encodeBreakingEntities } from '../../utilities'
+import { getNested, isEmptyObject, styleToString, encodeBreakingEntities, intersection } from '../../utilities'
 import { SlateToDomConfig } from '../..'
 
 type SlateToHtml = (node: any[], config?: SlateToDomConfig) => string
@@ -41,16 +41,18 @@ const slateNodeToHtml = (node: any, config = defaultConfig, isLastNodeInDocument
     strLines.forEach((line, index) => {
       const markElements: Element[] = []
 
+      const markTransformKeys = intersection(config.markTransforms || {}, node)
+
+      markTransformKeys.map((key) => {
+        if (config.markTransforms?.[key]) {
+          markElements.push(config.markTransforms[key]({ node, attribs: {} }))
+        }
+      })
+
       Object.keys(config.markMap).forEach((key) => {
         if ((node as any)[key]) {
           const elements: Element[] = config.markMap[key]
-            .map((tagName) => {
-              // more complex transforms
-              if (config.markTransforms?.[tagName]) {
-                return config.markTransforms[tagName]({ node, attribs: {} })
-              }
-              return new Element(tagName, {}, [])
-            })
+            .map((tagName) => new Element(tagName, {}, []))
           markElements.push(...elements)
         }
       })

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -83,3 +83,12 @@ export const encodeBreakingEntities = (str: string) => {
 
   return str
 }
+
+export const intersection = (o1: {[key: string]: any}, o2: {[key: string]: any}) => {
+  return Object.keys(o1).concat(Object.keys(o2)).sort().reduce(function (r: string[], a, i, aa) {
+      if (i && aa[i - 1] === a) {
+          r.push(a);
+      }
+      return r;
+  }, []);
+}


### PR DESCRIPTION
The `markTransforms` option was added to `SlateToDomConfig` in https://github.com/thompsonsj/slate-serializers/pull/63 in order to address https://github.com/thompsonsj/slate-serializers/issues/59.

On review, this option is confusing - and not very useful. It allows transform functions to be defined on HTML mark elements. e.g. anytime a `<strong>` HTML element tag is getting inserted, perform a transform function as defined.

It makes more sense to define mark transform functions on Slate JSON properties. For example, if a style object is set on a Slate child node, a transform function can be defined for that property. e.g. anytime a `style` property is found on a Slate node, return a `<span>` element with the style attributes added inline.

Functionality changed, tests added and docs updated.