### PR TITLE
refactor(src): export a type for elementTransform fns

### DIFF
--- a/__tests__/serializers/slateToHtml/payload.spec.ts
+++ b/__tests__/serializers/slateToHtml/payload.spec.ts
@@ -1,0 +1,104 @@
+import { Element } from 'domhandler'
+import { slateToHtml, payloadSlateToDomConfig, SlateToDomConfig, ElementTagTransformFunction } from '../../../src'
+
+describe('slateToHtml: Payload CMS config', () => {
+  it('renders an upload field as an `img` HTML element if an image', () => {
+    const html = '<img src="/images/pink-hour-au-cafe-bataclan-paris.jpg">'
+    const slate = [
+      {
+        "children": [
+            {
+                "text": ""
+            }
+        ],
+        "type": "upload",
+        "value": {
+            "id": "63389d417e803d5394b17873",
+            "filename": "pink-hour-au-cafe-bataclan-paris.jpg",
+            "mimeType": "image/jpeg",
+            "filesize": 240029,
+            "width": 1500,
+            "height": 844,
+            "createdAt": "2022-10-01T20:04:17.576Z",
+            "updatedAt": "2022-10-01T20:04:17.576Z",
+            "url": "/images/pink-hour-au-cafe-bataclan-paris.jpg"
+        },
+        "relationTo": "images"
+      },
+    ]
+    expect(slateToHtml(slate, payloadSlateToDomConfig)).toEqual(html)
+  })
+
+  it('renders an upload field as an `a` HTML element if not an image', () => {
+    const html = '<a href="/images/sample.pdf">sample.pdf</a>'
+    const slate = [
+      {
+        "children": [
+            {
+                "text": ""
+            }
+        ],
+        "type": "upload",
+        "value": {
+            "id": "64986c58bc75f7c64b244c24",
+            "filename": "sample.pdf",
+            "mimeType": "application/pdf",
+            "filesize": 3028,
+            "createdAt": "2023-06-25T16:33:28.780Z",
+            "updatedAt": "2023-06-25T16:33:28.780Z",
+            "url": "/images/sample.pdf"
+        },
+        "relationTo": "images"
+      },
+    ]
+    expect(slateToHtml(slate, payloadSlateToDomConfig)).toEqual(html)
+  })
+
+  it('renders an upload field as an `img` HTML element with a custom transform', () => {
+    const html = '<img class=\"object-cover object-center group-hover:opacity-75\" src=\"https://myapp.payloadcms.app//images/pink-hour-au-cafe-bataclan-paris.jpg\">'
+    const slate = [
+      {
+        "children": [
+            {
+                "text": ""
+            }
+        ],
+        "type": "upload",
+        "value": {
+            "id": "63389d417e803d5394b17873",
+            "filename": "pink-hour-au-cafe-bataclan-paris.jpg",
+            "mimeType": "image/jpeg",
+            "filesize": 240029,
+            "width": 1500,
+            "height": 844,
+            "createdAt": "2022-10-01T20:04:17.576Z",
+            "updatedAt": "2022-10-01T20:04:17.576Z",
+            "url": "/images/pink-hour-au-cafe-bataclan-paris.jpg"
+        },
+        "relationTo": "images"
+      },
+    ]
+    const uploadTransform: ElementTagTransformFunction = ({ node }) => {
+      if (node.value?.mimeType && node.value?.url) {
+        if (node.value?.mimeType.match(/^image/)) {
+          return new Element(
+            'img',
+            {
+              class: "object-cover object-center group-hover:opacity-75",
+              src: `https://myapp.payloadcms.app/${node.value?.url}`,
+            },
+          )
+        }
+      }
+    }
+
+    const config = {
+      ...payloadSlateToDomConfig,
+      elementTransforms: {
+        ...payloadSlateToDomConfig.elementTransforms,
+        upload: uploadTransform,
+      }
+    }
+    expect(slateToHtml(slate, config)).toEqual(html)
+  })
+})

--- a/__tests__/serializers/slateToHtml/payload.spec.ts
+++ b/__tests__/serializers/slateToHtml/payload.spec.ts
@@ -1,5 +1,5 @@
 import { Element } from 'domhandler'
-import { slateToHtml, payloadSlateToDomConfig, SlateToDomConfig, ElementTagTransformFunction } from '../../../src'
+import { slateToHtml, payloadSlateToDomConfig,  ElementTagTransformFunction } from '../../../src'
 
 describe('slateToHtml: Payload CMS config', () => {
   it('renders an upload field as an `img` HTML element if an image', () => {

--- a/src/config/slateToDom/payload.ts
+++ b/src/config/slateToDom/payload.ts
@@ -1,4 +1,4 @@
-import { Element } from 'domhandler'
+import { Element, Text } from 'domhandler'
 import { config as defaultConfig } from './default'
 import { SlateToDomConfig } from '../..'
 
@@ -28,6 +28,27 @@ export const config: SlateToDomConfig = {
         },
         children,
       )
+    },
+    upload: ({ node, children = [] }) => {
+      const attrs: any = {}
+      if (node.value?.mimeType && node.value?.url) {
+        if (node.value?.mimeType.match(/^image/)) {
+          return new Element(
+            'img',
+            {
+              src: node.value?.url,
+            },
+          )
+        } else {
+          return new Element(
+            'a',
+            {
+              href: node.value?.url,
+            },
+            [new Text(node.value?.filename)]
+          )
+        }
+      }
     },
   },
   defaultTag: 'p',

--- a/src/config/slateToDom/types.ts
+++ b/src/config/slateToDom/types.ts
@@ -4,8 +4,8 @@ interface MarkTagTransform {
   [key: string]: ({ node, attribs }: { node?: any; attribs?: { [key: string]: string } }) => Element
 }
 
-interface ElementTagTransform {
-  [key: string]: ({
+export type ElementTagTransformFunction = 
+  ({
     node,
     attribs,
     children,
@@ -13,7 +13,10 @@ interface ElementTagTransform {
     node?: any
     attribs?: { [key: string]: string }
     children?: ChildNode[]
-  }) => Element
+  }) => Element | undefined
+
+export interface ElementTagTransform {
+  [key: string]: ElementTagTransformFunction
 }
 
 export interface Config {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,6 @@ export { Config as HtmlToSlateConfig } from './config/htmlToSlate/types'
 export { config as htmlToSlateConfig } from './config/htmlToSlate/default'
 export { config as payloadHtmlToSlateConfig } from './config/htmlToSlate/payload'
 export { config as slateDemoHtmlToSlateConfig } from './config/htmlToSlate/slateDemo'
+
+// Useful types
+export { ElementTagTransformFunction } from './config/slateToDom/types'

--- a/src/utilities/convert-slate.ts
+++ b/src/utilities/convert-slate.ts
@@ -122,7 +122,7 @@ export const convertSlate = ({
   if (customElementTransforms && customElementTransforms[node.type]) {
     element = customElementTransforms[node.type]({ node, attribs, children })
   } else if (config.elementTransforms[node.type]) {
-    element = transformElement(config.elementTransforms[node.type]({ node, attribs, children }))
+    element = transformElement(config.elementTransforms[node.type]({ node, attribs, children }) as Element)
   }
 
   // straightforward node to element


### PR DESCRIPTION
- Export an `ElementTagTransformFunction` type to make it easier to write element transform functions for  configs of type`SlateToDomConfig`.
- Add basic support for the upload field to the default Payload CMS config and add tests.