### PR TITLE
Fixed call to gatherTextMarkAttributes using default config

### DIFF
--- a/src/serializers/htmlToSlate/index.ts
+++ b/src/serializers/htmlToSlate/index.ts
@@ -82,7 +82,7 @@ const deserialize = ({
   }
 
   if (config.textTags[nodeName] || el.type === ElementType.Text) {
-    const attrs = gatherTextMarkAttributes({ el: currentEl })
+    const attrs = gatherTextMarkAttributes({ el: currentEl,config })
     const text = processTextValue({
       text: textContent(el as Element),
       context: childrenContext as Context,


### PR DESCRIPTION
Call to gatherTextMarkAttributes in src\serializers\htmlToSlate\index.ts was not being passed the config object and was thus using the default config. 
This prevented custom textTags and other settings being correctly utilised.