### PR TITLE
chore(packages.json): bump to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slate-serializers/source",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "license": "MIT",
   "scripts": {
     "test": "nx run-many --all --target=test",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slate-serializers/dom",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Serialize Slate JSON objects to the DOM. Can be used with `htmlparser2` and associated utilities to modify the DOM and generate HTML. Used by other serializers in this monorepo.",
   "type": "commonjs"
 }

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@slate-serializers/html",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "type": "commonjs"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slate-serializers/react",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {

--- a/packages/slate-serializers/package.json
+++ b/packages/slate-serializers/package.json
@@ -1,5 +1,5 @@
 {
   "name": "slate-serializers",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "type": "commonjs"
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@slate-serializers/template",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "type": "commonjs"
 }

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@slate-serializers/tests",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "type": "commonjs"
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@slate-serializers/utilities",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "type": "commonjs"
 }


### PR DESCRIPTION
https://github.com/thompsonsj/slate-serializers/pull/109 is a breaking change - it changes the default config.

To restore to the original config, users needs to pass the original defaults.

```
slateToHtml(slate, {
    ...slateToHtmlConfig,
    encodeEntities: true,
    alwaysEncodeBreakingEntities: false,
})
```