### PR TITLE
fix(project.json): buildableProjectDepsInPackageJsonType

### DIFF
--- a/packages/slate-serializers/project.json
+++ b/packages/slate-serializers/project.json
@@ -11,7 +11,8 @@
         "outputPath": "dist/packages/slate-serializers",
         "main": "packages/slate-serializers/src/index.ts",
         "tsConfig": "packages/slate-serializers/tsconfig.lib.json",
-        "assets": ["packages/slate-serializers/*.md"]
+        "assets": ["packages/slate-serializers/*.md"],
+        "buildableProjectDepsInPackageJsonType": "dependencies"
       }
     },
     "publish": {


### PR DESCRIPTION
Without this change, `slate-serializers` requires `peerDepenendencies` to be installed.