### PR TITLE
fix(react): remove exports entry

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,11 +2,5 @@
    "name": "@slate-serializers/react",
    "version": "2.1.2",
    "main": "./index.js",
-   "types": "./index.d.ts",
-   "exports": {
-      ".": {
-         "import": "./index.mjs",
-         "require": "./index.js"
-      }
-   }
+   "types": "./index.d.ts"
 }


### PR DESCRIPTION
Without this fix, the following error message can occur in projects that use `@slate-serializers/react` depending on the TypeScript configuration.

```bash
Type error: Could not find a declaration file for module '@slate-serializers/react'. '<project-dir>/node_modules/@slate-serializers/react/index.mjs' implicitly has an 'any' type.
  There are types at '<project-dir>/node_modules/@slate-serializers/react/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@slate-serializers/react' library may need to update its package.json or typings.
```