### PR TITLE
fix(react): workaround non-bundled dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slate-serializers/source",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "scripts": {
     "test": "nx run-many --all --target=test",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@slate-serializers/dom",
-   "version": "2.1.4",
+   "version": "2.1.5",
    "description": "Serialize Slate JSON objects to the DOM. Can be used with `htmlparser2` and associated utilities to modify the DOM and generate HTML. Used by other serializers in this monorepo.",
    "type": "commonjs"
 }

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,5 +1,5 @@
 {
    "name": "@slate-serializers/html",
-   "version": "2.1.4",
+   "version": "2.1.5",
    "type": "commonjs"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,4 +1,7 @@
 {
    "name": "@slate-serializers/react",
-   "version": "2.1.4"
+   "version": "2.1.5",
+   "dependencies": {
+      "@slate-serializers/dom": "2.1.5"
+   }
 }

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -5,6 +5,13 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "deploy": {
+      "executor": "ngx-deploy-npm:deploy",
+      "options": {
+        "access": "public",
+        "buildTarget": "production"
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"]

--- a/packages/slate-serializers/package.json
+++ b/packages/slate-serializers/package.json
@@ -1,5 +1,5 @@
 {
    "name": "slate-serializers",
-   "version": "2.1.4",
+   "version": "2.1.5",
    "type": "commonjs"
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,5 +1,5 @@
 {
    "name": "@slate-serializers/template",
-   "version": "2.1.4",
+   "version": "2.1.5",
    "type": "commonjs"
 }

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,5 +1,5 @@
 {
    "name": "@slate-serializers/tests",
-   "version": "2.1.4",
+   "version": "2.1.5",
    "type": "commonjs"
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,5 +1,5 @@
 {
    "name": "@slate-serializers/utilities",
-   "version": "2.1.4",
+   "version": "2.1.5",
    "type": "commonjs"
 }

--- a/tools/sync-versions.js
+++ b/tools/sync-versions.js
@@ -3,9 +3,17 @@ const glob = require('glob');
 const fs = require('fs');
 
 glob.sync('./packages/**/package.json')
-  .forEach(location =>
+  .forEach(location => {
+    const packageJson = JSON.parse(fs.readFileSync(location))
     fs.writeFileSync(location, JSON.stringify({
-        ...JSON.parse(fs.readFileSync(location)),
-        version: mainPackageJson.version
+        ...packageJson,
+        version: mainPackageJson.version,
+        ...(packageJson.dependencies?.['@slate-serializers/dom'] && {
+          dependencies: {
+            ...packageJson.dependencies,
+            "@slate-serializers/dom": mainPackageJson.version
+          }
+        }),
     }, null, 3))
-  );
+  }
+);


### PR DESCRIPTION
Struggling to get `@slate-serializers/react` to bundle dependencies into the build `package.json`.

Resources:

- https://github.com/nrwl/nx/issues/10395
- https://stackoverflow.com/questions/71130822/building-an-nx-lib-with-rollup-does-not-bundle-required-dependencies

Fortunately, the package only relies on `@slate-serializers/dom`. Configure the version/deploy logic to ensure this package is always included as a dependency.