### PR TITLE
fix(slatetohtml): parse align attribute, add style object example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slate-serializers/source",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@slate-serializers/source",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",

--- a/packages/dom/src/lib/config/default.ts
+++ b/packages/dom/src/lib/config/default.ts
@@ -1,5 +1,6 @@
 import { Element } from 'domhandler'
 import { Config } from './types'
+import { styleToString } from '@slate-serializers/utilities'
 
 // Map Slate element names to HTML tag names
 // Staightforward transform - no attributes are considered
@@ -30,6 +31,16 @@ const MARK_ELEMENT_TAG_MAP = {
 export const config: Config = {
   markMap: MARK_ELEMENT_TAG_MAP,
   elementMap: ELEMENT_NAME_TAG_MAP,
+  elementAttributeTransform: ({ node }) => {
+    if (node.align) {
+      return {
+        style: styleToString({
+          ['text-align']: node.align,
+        })
+      }
+    }
+    return
+  },
   elementTransforms: {
     quote: ({ children = [] }) => {
       const p = [new Element('p', {}, children)]

--- a/packages/html/src/lib/serializers/htmlToSlate/config/types.ts
+++ b/packages/html/src/lib/serializers/htmlToSlate/config/types.ts
@@ -9,7 +9,7 @@ export type AttributeTransform = ({
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   el: Element
-}) => { [key: string]: string } | undefined
+}) => { [key: string]: unknown } | undefined
 
 /**
  * For details on configuration options:

--- a/packages/html/src/lib/serializers/snapshots/htmlToSlateToHtml.spec.ts
+++ b/packages/html/src/lib/serializers/snapshots/htmlToSlateToHtml.spec.ts
@@ -1,0 +1,201 @@
+import {
+  htmlToSlate,
+  htmlToSlateConfig,
+  slateToHtml,
+  type HtmlToSlateConfig,
+  SlateToHtmlConfig,
+  slateToHtmlConfig,
+} from '../../html';
+import {
+  transformStyleObjectToString,
+  transformStyleStringToObject,
+} from '@slate-serializers/utilities';
+
+const fixture = `<p>This is editable <strong>rich</strong> text, <i>much</i> better than a <pre><code>&lt;textarea&gt;</code></pre>!</p>
+
+<p>Since it&apos;s rich text, you can do things like turn a selection of text <strong>bold</strong>, or add a semantically rendered block quote in the middle of the page, like this:</p>
+
+<blockquote>A wise quote.</blockquote>
+
+<p style="text-align:center;">Try it out for yourself!</p>`;
+
+describe('Slate JS example', () => {
+  const slate = htmlToSlate(fixture);
+
+  it('generates expected htmlToSlate output', () => {
+    expect(slate).toMatchInlineSnapshot(`
+      [
+        {
+          "children": [
+            {
+              "text": "This is editable ",
+            },
+            {
+              "bold": true,
+              "text": "rich",
+            },
+            {
+              "text": " text, ",
+            },
+            {
+              "italic": true,
+              "text": "much",
+            },
+            {
+              "text": " better than a ",
+            },
+            {
+              "code": true,
+              "text": "<textarea>",
+            },
+            {
+              "text": "!",
+            },
+          ],
+          "type": "p",
+        },
+        {
+          "children": [
+            {
+              "text": "Since it's rich text, you can do things like turn a selection of text ",
+            },
+            {
+              "bold": true,
+              "text": "bold",
+            },
+            {
+              "text": ", or add a semantically rendered block quote in the middle of the page, like this:",
+            },
+          ],
+          "type": "p",
+        },
+        {
+          "children": [
+            {
+              "text": "A wise quote.",
+            },
+          ],
+          "type": "blockquote",
+        },
+        {
+          "align": "center",
+          "children": [
+            {
+              "text": "Try it out for yourself!",
+            },
+          ],
+          "type": "p",
+        },
+      ]
+    `);
+  });
+
+  it('generates expected slateToHtml output', () => {
+    expect(slateToHtml(slate)).toMatchInlineSnapshot(
+      `"<p>This is editable <strong>rich</strong> text, <i>much</i> better than a <pre><code>&lt;textarea&gt;</code></pre>!</p><p>Since it's rich text, you can do things like turn a selection of text <strong>bold</strong>, or add a semantically rendered block quote in the middle of the page, like this:</p><blockquote>A wise quote.</blockquote><p style="text-align:center;">Try it out for yourself!</p>"`
+    );
+  });
+});
+
+describe('Slate JS example - with style utilities', () => {
+  const config: HtmlToSlateConfig = {
+    ...htmlToSlateConfig,
+    elementAttributeTransform: ({ el }) => {
+      const style =
+        el.attribs['style'] &&
+        transformStyleStringToObject(el.attribs['style']);
+      return {
+        ...(style && { style }),
+      };
+    },
+  };
+  const slate = htmlToSlate(fixture, config);
+
+  it('generates expected htmlToSlate output', () => {
+    expect(slate).toMatchInlineSnapshot(`
+      [
+        {
+          "children": [
+            {
+              "text": "This is editable ",
+            },
+            {
+              "bold": true,
+              "text": "rich",
+            },
+            {
+              "text": " text, ",
+            },
+            {
+              "italic": true,
+              "text": "much",
+            },
+            {
+              "text": " better than a ",
+            },
+            {
+              "code": true,
+              "text": "<textarea>",
+            },
+            {
+              "text": "!",
+            },
+          ],
+          "type": "p",
+        },
+        {
+          "children": [
+            {
+              "text": "Since it's rich text, you can do things like turn a selection of text ",
+            },
+            {
+              "bold": true,
+              "text": "bold",
+            },
+            {
+              "text": ", or add a semantically rendered block quote in the middle of the page, like this:",
+            },
+          ],
+          "type": "p",
+        },
+        {
+          "children": [
+            {
+              "text": "A wise quote.",
+            },
+          ],
+          "type": "blockquote",
+        },
+        {
+          "children": [
+            {
+              "text": "Try it out for yourself!",
+            },
+          ],
+          "style": {
+            "textAlign": "center",
+          },
+          "type": "p",
+        },
+      ]
+    `);
+  });
+
+  it('generates expected slateToHtml output', () => {
+    const config: SlateToHtmlConfig = {
+      ...slateToHtmlConfig,
+      elementAttributeTransform: ({ node }) => {
+        if (node.style) {
+          return {
+            style: transformStyleObjectToString(node.style),
+          };
+        }
+        return undefined;
+      },
+    };
+
+    expect(slateToHtml(slate, config)).toMatchInlineSnapshot(
+      `"<p>This is editable <strong>rich</strong> text, <i>much</i> better than a <pre><code>&lt;textarea&gt;</code></pre>!</p><p>Since it's rich text, you can do things like turn a selection of text <strong>bold</strong>, or add a semantically rendered block quote in the middle of the page, like this:</p><blockquote>A wise quote.</blockquote><p style="text-align: center">Try it out for yourself!</p>"`
+    );
+  });
+});


### PR DESCRIPTION
Ensure that both `slateToHtml` and `htmlToSlate` default configurations parse the `text-align` CSS attribute in the same way.

See:

- https://github.com/thompsonsj/slate-serializers/issues/118
- https://github.com/thompsonsj/slate-serializers/issues/59

...also lack of `align` attribute support has been mentioned a few times in the Payload CMS Discord. The `elementAttributeTransform` property on the `htmlToSlate` default config is imported by the Payload CMS config, so `text-align` on a style attribute will be transformed to the expected Slate JSON attribute for https://github.com/payloadcms/payload/tree/main/packages/richtext-slate.

Finally, an example is added through a test of how to use the `transformStyleObjectToString` and `transformStyleStringToObject` functions from `@slate-serializers/utilities` to transform all styles back and forth using https://github.com/postcss/postcss-js.