### PR TITLE
patch(payload): adding textAlign key to be used

### DIFF
--- a/packages/dom/src/lib/config/payload.ts
+++ b/packages/dom/src/lib/config/payload.ts
@@ -1,6 +1,7 @@
 import { Element, Text } from 'domhandler'
 import { config as defaultConfig } from './default'
 import { SlateToDomConfig } from '../..'
+import { styleToString } from '@slate-serializers/utilities';
 
 /**
  * Configuration for Payload CMS
@@ -10,6 +11,16 @@ import { SlateToDomConfig } from '../..'
 
 export const config: SlateToDomConfig = {
   ...defaultConfig,
+  elementAttributeTransform: ({ node }) => {
+    if (node.align || node.textAlign) {
+      return {
+        style: styleToString({
+          ['text-align']: node.align || node.textAlign,
+        })
+      }
+    }
+    return
+  },
   elementTransforms: {
     ...defaultConfig.elementTransforms,
     link: ({ node, children = [] }) => {


### PR DESCRIPTION
When testing the html searlizer, I noticed that the text alignment wasn't being honored. Looking at the data that was created when using slate js with payload, it sets the textAlignment field. This PR checks both the align or textAlign field for the payload config

`[{"type": "h1", "children": [{"text": "Test body with image"}], "textAlign": "center"}, {"children": [{"text": ""}]}, {"type": "upload", "value": {"id": 4}, "children": [{"text": ""}], "textAlign": "center", "relationTo": "media"}, {"children": [{"text": ""}]}, {"children": [{"text": ""}]}, {"children": [{"text": "Some other text"}]}]`