### PR TITLE
fix(tsconfig): disable sourceMap

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "sourceMap": true,
+    "inlineSources": true,
     "declaration": false,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,9 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "rootDir": ".",
-    "sourceMap": true,
-    "inlineSources": true,
-    "declaration": false,
+    "sourceMap": false,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "sourceMap": false,
+    "declaration": false,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Fix https://github.com/thompsonsj/slate-serializers/issues/146.

Disable source map generation in the npm package bundle.

Source maps offer developer convenience. I have experimented with different `tsconfig` options to try to try and resolve this issue while still supporting source maps, but to no avail. See https://github.com/nrwl/nx/issues/11179 for more information on the problem.

Seems more appropriate to disable source map generation and therefore remove warnings for source maps that were not working anyway.