### PR TITLE
feat(react): flatten config

### DIFF
--- a/packages/dom/src/lib/config/payload.ts
+++ b/packages/dom/src/lib/config/payload.ts
@@ -24,12 +24,12 @@ export const config: SlateToDomConfig = {
   elementTransforms: {
     ...defaultConfig.elementTransforms,
     link: ({ node, children = [] }) => {
-      const attrs: any = {}
+      const attrs: {[key: string]: string} = {}
       if (node.linkType) {
         attrs['data-link-type'] = node.linkType
       }
       if (node.newTab) {
-        attrs.target = '_blank'
+        attrs['target'] = '_blank'
       }
       return new Element(
         'a',

--- a/packages/react/src/lib/__tests__/#175.spec.tsx
+++ b/packages/react/src/lib/__tests__/#175.spec.tsx
@@ -4,7 +4,7 @@ import {
   SlateToReact,
   payloadSlateToReactConfig,
   SlateToReactConfig,
-} from '@slate-serializers/react';
+} from './../react';
 
 import { comprehensiveExampleSlate } from './fixtures/payload/comprehensive';
 
@@ -104,39 +104,34 @@ describe('Issue 175', () => {
 
   it('convert fixture with Payload config with customisations based on #175', () => {
     const config: SlateToReactConfig = {
-      react: {
-        ...payloadSlateToReactConfig.react,
-        elementTransforms: {
-          ...payloadSlateToReactConfig.react.elementTransforms,
-          upload: ({ node, attribs, children }) => {
-            if (node.value?.mimeType && node.value?.url) {
-              if (node.value?.mimeType.match(/^image/)) {
-                return (
-                  <img
-                    src={node.value.url}
-                    alt={node.value.alt || node.value.filename}
-                    className={'w-full border-2'}
-                  />
-                );
-              }
+      ...payloadSlateToReactConfig,
+      elementTransforms: {
+        ...payloadSlateToReactConfig.elementTransforms,
+        upload: ({ node, attribs, children }) => {
+          if (node.value?.mimeType && node.value?.url) {
+            if (node.value?.mimeType.match(/^image/)) {
+              return (
+                <img
+                  src={node.value.url}
+                  alt={node.value.alt || node.value.filename}
+                  className={'w-full border-2'}
+                />
+              );
             }
-            return;
-          },
+          }
+          return;
         },
       },
-      dom: {
-        ...payloadSlateToReactConfig.dom,
-        defaultTag: 'p',
-        markMap: {
-          ...payloadSlateToReactConfig.dom.markMap,
-          strikethrough: ['s'],
-          bold: ['strong'],
-          underline: ['u'],
-          italic: ['i'],
-          code: ['code'],
-        },
-        alwaysEncodeBreakingEntities: false,
+      defaultTag: 'p',
+      markMap: {
+        ...payloadSlateToReactConfig.markMap,
+        strikethrough: ['s'],
+        bold: ['strong'],
+        underline: ['u'],
+        italic: ['i'],
+        code: ['code'],
       },
+      alwaysEncodeBreakingEntities: false,
     };
 
     const tree = renderer

--- a/packages/react/src/lib/__tests__/default.spec.tsx
+++ b/packages/react/src/lib/__tests__/default.spec.tsx
@@ -1,5 +1,6 @@
 import renderer from 'react-test-renderer';
-import { SlateToReact } from './../react';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { SlateToReact } from '@slate-serializers/react';
 import { config as defaultReactConfig } from './../config/default';
 
 describe('React conversion', () => {

--- a/packages/react/src/lib/__tests__/default.spec.tsx
+++ b/packages/react/src/lib/__tests__/default.spec.tsx
@@ -1,5 +1,5 @@
 import renderer from 'react-test-renderer';
-import { SlateToReact } from './../serializers';
+import { SlateToReact } from './../react';
 import { config as defaultReactConfig } from './../config/default';
 
 describe('React conversion', () => {
@@ -88,10 +88,7 @@ describe('React conversion', () => {
 
     const config = {
       ...defaultReactConfig,
-      dom: {
-        ...defaultReactConfig.dom,
-        defaultTag: 'p',
-      },
+      defaultTag: 'p',
     };
 
     const tree = renderer

--- a/packages/react/src/lib/__tests__/payload-crowdin-sync-dev/payload-internal-link.spec.tsx
+++ b/packages/react/src/lib/__tests__/payload-crowdin-sync-dev/payload-internal-link.spec.tsx
@@ -78,28 +78,25 @@ describe('React conversion - Payload CMS fixtures', () => {
   test('convert internal link with customised config', async () => {
     const config: SlateToReactConfig = {
       ...payloadSlateToReactConfig,
-      react: {
-        ...payloadSlateToReactConfig.react,
-        elementTransforms: {
-          ...payloadSlateToReactConfig.react.elementTransforms,
-          link: ({ node, children = [] }) => {
-            const attrs: any = {};
-            if (node.linkType) {
-              attrs['data-link-type'] = node.linkType;
-            }
-            if (node.newTab) {
-              attrs.target = '_blank';
-            }
-            const doc = node.doc?.value;
-            if (isPost(doc) && node.linkType === 'internal') {
-              attrs.href = `https://example.com/${doc.id}`;
-            }
-            return (
-              <a href={node.url} {...attrs}>
-                {children}
-              </a>
-            );
-          },
+      elementTransforms: {
+        ...payloadSlateToReactConfig.elementTransforms,
+        link: ({ node, children = [] }) => {
+          const attrs: any = {};
+          if (node.linkType) {
+            attrs['data-link-type'] = node.linkType;
+          }
+          if (node.newTab) {
+            attrs.target = '_blank';
+          }
+          const doc = node.doc?.value;
+          if (isPost(doc) && node.linkType === 'internal') {
+            attrs.href = `https://example.com/${doc.id}`;
+          }
+          return (
+            <a href={node.url} {...attrs}>
+              {children}
+            </a>
+          );
         },
       },
     };

--- a/packages/react/src/lib/__tests__/payload-crowdin-sync-dev/payload-internal-link.spec.tsx
+++ b/packages/react/src/lib/__tests__/payload-crowdin-sync-dev/payload-internal-link.spec.tsx
@@ -1,9 +1,10 @@
 import renderer from 'react-test-renderer';
+// eslint-disable-next-line @nx/enforce-module-boundaries
 import {
   SlateToReact,
   SlateToReactConfig,
   payloadSlateToReactConfig,
-} from '../../react';
+} from '@slate-serializers/react';
 import { Post } from './payload-types';
 
 // Type guard for Post

--- a/packages/react/src/lib/config/default.tsx
+++ b/packages/react/src/lib/config/default.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { Config } from './types'
 import { ulid } from 'ulidx'
 import { slateToDomConfig } from '@slate-serializers/dom'
@@ -10,25 +10,28 @@ const BlockQuote = ({ children }: { children: ReactNode }) => (
 )
 
 export const config: Config = {
-  dom: {
-    ...slateToDomConfig,
-  },
-  react: {
-    elementTransforms: {
-      quote: ({ children }) => {
-        return <BlockQuote key={ulid()}>{children}</BlockQuote>
-      },
-      link: ({ node, children = [] }) => {
-        const attrs: any = {}
-        if (node.newTab) {
-          attrs.target = '_blank'
-        }
-        return (
-          <a key={ulid()} href={node.url} {...attrs}>
-            {children}
-          </a>
-        )
-      },
+  markMap: slateToDomConfig.markMap,
+  elementMap: slateToDomConfig.elementMap,
+  elementAttributeTransform: slateToDomConfig.elementAttributeTransform,
+  defaultTag: slateToDomConfig.defaultTag,
+  encodeEntities: slateToDomConfig.encodeEntities,
+  alwaysEncodeBreakingEntities: slateToDomConfig.alwaysEncodeBreakingEntities,
+  alwaysEncodeCodeEntities: slateToDomConfig.alwaysEncodeCodeEntities,
+  convertLineBreakToBr: slateToDomConfig.convertLineBreakToBr,
+  elementTransforms: {
+    quote: ({ children }) => {
+      return <BlockQuote key={ulid()}>{children}</BlockQuote>
+    },
+    link: ({ node, children = [] }) => {
+      const attrs: {[key: string]: string} = {}
+      if (node.newTab) {
+        attrs.target = '_blank'
+      }
+      return (
+        <a key={ulid()} href={node.url} {...attrs}>
+          {children}
+        </a>
+      )
     },
   },
 }

--- a/packages/react/src/lib/config/payload.tsx
+++ b/packages/react/src/lib/config/payload.tsx
@@ -1,33 +1,38 @@
-import { config as defaultConfig } from './default'
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { slateToReactConfig } from '@slate-serializers/react'
 import { payloadSlateToDomConfig } from '@slate-serializers/dom'
 import { Config as SlateToReactConfig } from './types'
+import { ulid } from 'ulidx'
 
 /**
  * Configuration for Payload CMS
  *
  * Tested for v1.1.21
  */
-
 export const config: SlateToReactConfig = {
-  ...defaultConfig,
-  dom: payloadSlateToDomConfig,
-  react: {
-    elementTransforms: {
-      ...defaultConfig.react.elementTransforms,
-      link: ({ node, children = [] }) => {
-        const attrs: any = {}
-        if (node.linkType) {
-          attrs['data-link-type'] = node.linkType
-        }
-        if (node.newTab) {
-          attrs.target = '_blank'
-        }
-        return (
-          <a href={node.url} {...attrs}>
-            {children}
-          </a>
-        )
-      },
+  markMap: payloadSlateToDomConfig.markMap,
+  elementMap: payloadSlateToDomConfig.elementMap,
+  elementAttributeTransform: payloadSlateToDomConfig.elementAttributeTransform,
+  defaultTag: payloadSlateToDomConfig.defaultTag,
+  encodeEntities: payloadSlateToDomConfig.encodeEntities,
+  alwaysEncodeBreakingEntities: payloadSlateToDomConfig.alwaysEncodeBreakingEntities,
+  alwaysEncodeCodeEntities: payloadSlateToDomConfig.alwaysEncodeCodeEntities,
+  convertLineBreakToBr: payloadSlateToDomConfig.convertLineBreakToBr,
+  elementTransforms: {
+    ...slateToReactConfig.elementTransforms,
+    link: ({ node, children = [] }) => {
+      const attrs: {[key: string]: string} = {}
+      if (node.linkType) {
+        attrs['data-link-type'] = node.linkType
+      }
+      if (node.newTab) {
+        attrs.target = '_blank'
+      }
+      return (
+        <a key={ulid()} href={node.url} {...attrs}>
+          {children}
+        </a>
+      )
     },
   },
 }

--- a/packages/react/src/lib/config/payload.tsx
+++ b/packages/react/src/lib/config/payload.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { slateToReactConfig } from '@slate-serializers/react'
+import { config as slateToReactConfig } from './default'
 import { payloadSlateToDomConfig } from '@slate-serializers/dom'
 import { Config as SlateToReactConfig } from './types'
 import { ulid } from 'ulidx'

--- a/packages/react/src/lib/config/types.ts
+++ b/packages/react/src/lib/config/types.ts
@@ -17,10 +17,7 @@ interface ElementTagTransform {
   }) => ReactNode
 }
 
-export interface Config {
-  dom: BaseConfig
-  react: {
-    markTransforms?: MarkTagTransform
-    elementTransforms: ElementTagTransform
-  }
+export interface Config extends BaseConfig {
+  markTransforms?: MarkTagTransform
+  elementTransforms: ElementTagTransform
 }

--- a/packages/react/src/lib/serializers.tsx
+++ b/packages/react/src/lib/serializers.tsx
@@ -20,12 +20,12 @@ export const SlateToReact = ({ node, config = slateToReactConfig }: ISlateToReac
     convertSlate({
       node: n,
       config: {
-        ...config.dom,
+        ...config,
         elementTransforms: {},
         markTransforms: {},
       },
       isLastNodeInDocument: index === node.length - 1,
-      customElementTransforms: config.react.elementTransforms,
+      customElementTransforms: config.elementTransforms,
       transformText: (text) => transformText(text),
       transformElement: (element) => {
         return domElementToReactElement(element)

--- a/packages/tests/src/lib/react/components.spec.tsx
+++ b/packages/tests/src/lib/react/components.spec.tsx
@@ -51,12 +51,10 @@ describe('slateToReact: map element to button component', () => {
 
     const reactConfig: SlateToReactConfig = {
       ...defaultReactConfig,
-      react: {
-        elementTransforms: {
-          ...defaultReactConfig.react.elementTransforms,
-          button: ({ node, children = [] }) => {
-            return <Button onClick={onClick}>{children}</Button>
-          },
+      elementTransforms: {
+        ...defaultReactConfig.elementTransforms,
+        button: ({ node, children = [] }) => {
+          return <Button onClick={onClick}>{children}</Button>
         },
       },
     }

--- a/packages/tests/src/lib/react/style-object.spec.tsx
+++ b/packages/tests/src/lib/react/style-object.spec.tsx
@@ -2,6 +2,7 @@ import renderer from 'react-test-renderer'
 import { SlateToReact, slateToReactConfig as defaultReactConfig, SlateToReactConfig } from '@slate-serializers/react'
 import { styleObjectFixtures } from './../tests'
 import { transformStyleObjectToString } from '@slate-serializers/utilities'
+import React from 'react'
 
 const reactConfig: SlateToReactConfig = {
   ...defaultReactConfig,

--- a/packages/tests/src/lib/react/style-object.spec.tsx
+++ b/packages/tests/src/lib/react/style-object.spec.tsx
@@ -5,12 +5,9 @@ import { transformStyleObjectToString } from '@slate-serializers/utilities'
 
 const reactConfig: SlateToReactConfig = {
   ...defaultReactConfig,
-  dom: {
-    ...defaultReactConfig.dom,
-    elementAttributeTransform: ({ node }) => {
-      const style = transformStyleObjectToString(node.style)
-      return style ? { style } : undefined
-    }
+  elementAttributeTransform: ({ node }) => {
+    const style = transformStyleObjectToString(node.style)
+    return style ? { style } : undefined
   }
 }
 


### PR DESCRIPTION
This is a breaking change for the `SlateToReact` serializer that removes the `react` and `dom` property names.

Update your usage of the serializer by removing these keys.

For example, before this change, custom configuration was quite messy as it was necessary to spread more values within the default configuration.

```ts
import { SlateToReact, slateToReactConfig as defaultReactConfig, SlateToReactConfig } from '@slate-serializers/react'

const config: SlateToReactConfig = {
  ...defaultReactConfig,
  dom: {
    ...defaultReactConfig.dom,
    defaultTag: 'p',
  },
  react: {
    ...defaultReactConfig.react,
    elementTransforms: {
      ...defaultReactConfig.react.elementTransforms,
      button: ({ node, children = [] }) => {
        return <Button onClick={onClick}>{children}</Button>
      },
    },
  },
};
```

After the change:

```ts
import { SlateToReact, slateToReactConfig as defaultReactConfig, SlateToReactConfig } from '@slate-serializers/react'

const config: SlateToReactConfig = {
  ...defaultReactConfig,
  defaultTag: 'p',
  elementTransforms: {
    ...defaultReactConfig.elementTransforms,
    button: ({ node, children = [] }) => {
      return <Button onClick={onClick}>{children}</Button>
    },
  },
};
```

More examples can be found in this pull request as config customisation is changed for passing tests.