### PR TITLE
fix(convertslate): create helpers, increase test converage, fix fallback bug

### DIFF
--- a/packages/dom/src/lib/utilities/convert-slate.spec.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.spec.ts
@@ -536,5 +536,49 @@ describe('convertSlate', () => {
 
     expect(html(out)).toEqual('<span id="wrapped">x</span>')
   })
+
+  it('transformText can be used to traverse and rewrite nested Text nodes (e.g. inside marks)', () => {
+    const config: Config = {
+      markMap: { bold: ['strong'] },
+      elementMap: {},
+      elementTransforms: {},
+      convertLineBreakToBr: false,
+    }
+
+    const rewrite = (n: any): any => {
+      if (n instanceof Text) {
+        return new Text(`[${n.data}]`)
+      }
+      if (n instanceof Element) {
+        return new Element(n.name, n.attribs, (n.children || []).map(rewrite))
+      }
+      return n
+    }
+
+    const out = convertSlate({
+      node: { text: 't', bold: true },
+      config,
+      transformText: rewrite,
+    })
+
+    expect(html(out)).toEqual('<strong>[t]</strong>')
+  })
+
+  it('wrapChildren affects the container for marked text (not just plain text)', () => {
+    const config: Config = {
+      markMap: { bold: ['strong'] },
+      elementMap: {},
+      elementTransforms: {},
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: 't', bold: true },
+      config,
+      wrapChildren: (children) => new Element('span', { id: 'wrapped' }, children),
+    })
+
+    expect(html(out)).toEqual('<span id="wrapped"><strong>t</strong></span>')
+  })
 })
 

--- a/packages/dom/src/lib/utilities/convert-slate.spec.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.spec.ts
@@ -213,5 +213,53 @@ describe('convertSlate', () => {
     // overridden by markTransforms[tagName]).
     expect(html(out)).toEqual('<span style="font-size:12px;"><b>t</b></span>')
   })
+
+  it('markTransforms can override only one tag in a multi-tag markMap entry', () => {
+    const config: Config = {
+      markMap: {
+        codeMark: ['pre', 'code'],
+      },
+      markTransforms: {
+        // Override only the inner <code> tag.
+        code: () => new Element('kbd', {}, []),
+      },
+      elementMap: {},
+      elementTransforms: {},
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: 'x', codeMark: true },
+      config,
+    })
+
+    expect(html(out)).toEqual('<pre><kbd>x</kbd></pre>')
+  })
+
+  it('does not emit attributes when elementAttributeTransform returns empty or undefined', () => {
+    const base: Omit<Config, 'elementAttributeTransform'> = {
+      markMap: {},
+      elementMap: { p: 'p' },
+      elementTransforms: {},
+    }
+
+    const outUndefined = convertSlate({
+      node: { type: 'p', children: [{ text: 'x' }] },
+      config: {
+        ...base,
+        elementAttributeTransform: () => undefined,
+      },
+    })
+    expect(html(outUndefined)).toEqual('<p>x</p>')
+
+    const outEmpty = convertSlate({
+      node: { type: 'p', children: [{ text: 'x' }] },
+      config: {
+        ...base,
+        elementAttributeTransform: () => ({}),
+      },
+    })
+    expect(html(outEmpty)).toEqual('<p>x</p>')
+  })
 })
 

--- a/packages/dom/src/lib/utilities/convert-slate.spec.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.spec.ts
@@ -261,5 +261,123 @@ describe('convertSlate', () => {
     })
     expect(html(outEmpty)).toEqual('<p>x</p>')
   })
+
+  it('markTransforms can be applied both by Slate prop keys and by markMap tagName overrides', () => {
+    const config: Config = {
+      markMap: {
+        // A mark that uses a tagName that also has a transform.
+        code: ['pre', 'code'],
+      },
+      markTransforms: {
+        // Applied because Slate leaf has `code: true` (markTransformKeys).
+        code: () => new Element('kbd', {}, []),
+      },
+      elementMap: {},
+      elementTransforms: {},
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: 'x', code: true },
+      config,
+    })
+
+    // `code` is applied twice:
+    // - once because the Slate leaf has `code: true` (markTransforms.code)
+    // - once because markMap includes tagName `code`, and markTransforms['code'] overrides tag creation
+    expect(html(out)).toEqual('<kbd><pre><kbd>x</kbd></pre></kbd>')
+  })
+
+  it('elementAttributeTransform attribs are passed into elementTransforms and can be overridden by the transform result', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {
+        p: 'p',
+      },
+      elementAttributeTransform: ({ node }: { node: any }) => {
+        return node.id ? { 'data-id': String(node.id), class: 'from-attribute-transform' } : undefined
+      },
+      elementTransforms: {
+        p: ({ attribs, children = [] }) => {
+          // ElementTransform receives attribs with elementAttributeTransform already applied.
+          return new Element(
+            'p',
+            {
+              ...attribs,
+              // Override one attr
+              class: 'from-element-transform',
+            },
+            children,
+          )
+        },
+      },
+    }
+
+    const out = convertSlate({
+      node: { type: 'p', id: 1, children: [{ text: 'x' }] },
+      config,
+    })
+
+    expect(html(out)).toEqual('<p data-id="1" class="from-element-transform">x</p>')
+  })
+
+  it('customElementTransforms receive attribs and can override elementTransforms and elementMap', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {
+        p: 'p',
+      },
+      elementAttributeTransform: () => ({ class: 'from-attribute-transform' }),
+      elementTransforms: {
+        p: ({ attribs, children = [] }) => new Element('p', { ...attribs, class: 'from-element-transform' }, children),
+      },
+    }
+
+    const out = convertSlate({
+      node: { type: 'p', children: [{ text: 'x' }] },
+      config,
+      customElementTransforms: {
+        p: ({ attribs, children = [] }: { attribs: any; children?: any[] }) =>
+          new Element('p', { ...attribs, class: 'from-custom-transform' }, children),
+      },
+    })
+
+    expect(html(out)).toEqual('<p class="from-custom-transform">x</p>')
+  })
+
+  it('falls back to elementMap when elementTransforms returns undefined', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {
+        p: 'p',
+      },
+      elementTransforms: {
+        p: () => undefined,
+      },
+    }
+
+    const out = convertSlate({
+      node: { type: 'p', children: [{ text: 'x' }] },
+      config,
+    })
+
+    expect(html(out)).toEqual('<p>x</p>')
+  })
+
+  it('falls back to defaultTag when no type and no mapping exists', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {},
+      elementTransforms: {},
+      defaultTag: 'div',
+    }
+
+    const out = convertSlate({
+      node: { children: [{ text: 'x' }] },
+      config,
+    })
+
+    expect(html(out)).toEqual('<div>x</div>')
+  })
 })
 

--- a/packages/dom/src/lib/utilities/convert-slate.spec.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.spec.ts
@@ -159,5 +159,59 @@ describe('convertSlate', () => {
     // markMap iteration order is the insertion order of keys: bold then italic.
     expect(html(out)).toEqual('<strong><i>t</i></strong>')
   })
+
+  it('when both breaking-entity and code-entity encoding are enabled, pre/code text is encoded once in Text.data', () => {
+    const config: Config = {
+      markMap: {
+        code: ['pre', 'code'],
+      },
+      elementMap: {},
+      elementTransforms: {},
+      encodeEntities: false,
+      alwaysEncodeBreakingEntities: true,
+      alwaysEncodeCodeEntities: true,
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: '2 & 1 < 3 > 0', code: true },
+      config,
+    }) as unknown as Document
+
+    const pre = out.children[0] as Element
+    const code = pre.children[0] as Element
+    const text = code.children[0] as Text
+
+    // We assert on Text.data (DOM content), not on the serialized HTML string, to avoid
+    // double-encoding artifacts when serializing already-escaped entities.
+    expect(text.data).toEqual('2 &amp; 1 &lt; 3 &gt; 0')
+  })
+
+  it('markTransforms can override markMap tag behavior', () => {
+    const config: Config = {
+      markMap: {
+        bold: ['strong'],
+      },
+      markTransforms: {
+        // Override the default <strong> element creation.
+        strong: () => new Element('b', {}, []),
+        // Add a custom mark driven by a Slate leaf prop.
+        fontSize: ({ node }) =>
+          node ? new Element('span', { style: `font-size:${(node as any).fontSize};` }, []) : undefined,
+      },
+      elementMap: {},
+      elementTransforms: {},
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: 't', bold: true, fontSize: '12px' },
+      config,
+    })
+
+    // markTransforms (matching Slate props) are applied first, then markMap tags (which can be
+    // overridden by markTransforms[tagName]).
+    expect(html(out)).toEqual('<span style="font-size:12px;"><b>t</b></span>')
+  })
 })
 

--- a/packages/dom/src/lib/utilities/convert-slate.spec.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.spec.ts
@@ -1,0 +1,93 @@
+import serializer from 'dom-serializer'
+import { Document, Element, Text } from 'domhandler'
+import { getName } from 'domutils'
+
+import type { AnyNode } from 'domhandler'
+import type { Config } from '../config/types'
+import { convertSlate } from './convert-slate'
+
+const html = (node: AnyNode | ArrayLike<AnyNode>) => serializer(node as AnyNode)
+
+describe('convertSlate', () => {
+  it('prefers customElementTransforms over config.elementTransforms over elementMap', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {
+        p: 'p',
+      },
+      elementTransforms: {
+        p: ({ children = [] }) => new Element('div', {}, children),
+      },
+    }
+
+    const node = {
+      type: 'p',
+      children: [{ text: 'Hello' }],
+    }
+
+    const out = convertSlate({
+      node,
+      config,
+      customElementTransforms: {
+        p: ({ children = [] }: { children?: any[] }) => new Element('section', {}, children),
+      },
+    })
+
+    expect(html(out)).toEqual('<section>Hello</section>')
+  })
+
+  it('encodes entities inside <pre> when alwaysEncodeCodeEntities is enabled', () => {
+    const config: Config = {
+      markMap: {
+        code: ['pre', 'code'],
+      },
+      elementMap: {},
+      elementTransforms: {},
+      encodeEntities: false,
+      alwaysEncodeBreakingEntities: false,
+      alwaysEncodeCodeEntities: true,
+      convertLineBreakToBr: false,
+    }
+
+    const node = {
+      text: `2 & 1 < 3 > 0`,
+      code: true,
+    }
+
+    const out = convertSlate({ node, config })
+    const doc = out as unknown as Document
+    expect(doc.children).toHaveLength(1)
+    const pre = doc.children[0] as Element
+    expect(getName(pre)).toEqual('pre')
+    expect(pre.children).toHaveLength(1)
+    const code = pre.children[0] as Element
+    expect(getName(code)).toEqual('code')
+    expect(code.children).toHaveLength(1)
+    const text = code.children[0] as Text
+    expect(text.data).toEqual('2 &amp; 1 &lt; 3 &gt; 0')
+  })
+
+  it('adds a trailing <br> between sibling inline nodes when enabled', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {},
+      elementTransforms: {},
+      convertLineBreakToBr: true,
+    }
+
+    const first = convertSlate({
+      node: { children: [{ text: 'a' }] },
+      config,
+      isLastNodeInDocument: false,
+    })
+    const last = convertSlate({
+      node: { children: [{ text: 'b' }] },
+      config,
+      isLastNodeInDocument: true,
+    })
+
+    expect(html(first)).toEqual('a<br>')
+    expect(html(last)).toEqual('b')
+  })
+})
+

--- a/packages/dom/src/lib/utilities/convert-slate.spec.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.spec.ts
@@ -460,5 +460,81 @@ describe('convertSlate', () => {
     const text = out.children[0] as Text
     expect(text.data).toEqual('2 & 1 < 3 > 0')
   })
+
+  it('preserves style string attributes from elementAttributeTransform', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: { p: 'p' },
+      elementTransforms: {},
+      elementAttributeTransform: () => ({
+        style: 'text-align:right;',
+      }),
+    }
+
+    const out = convertSlate({
+      node: { type: 'p', children: [{ text: 'x' }] },
+      config,
+    })
+
+    expect(html(out)).toEqual('<p style="text-align:right;">x</p>')
+  })
+
+  it('applies transformElement to elements created from elementMap and to inserted <br>', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: { p: 'p' },
+      elementTransforms: {},
+      convertLineBreakToBr: true,
+    }
+
+    const out = convertSlate({
+      node: { type: 'p', children: [{ text: 'a\nb' }] },
+      config,
+      // turn every element into a <div> wrapper for visibility
+      transformElement: (el) => new Element('div', { 'data-tag': (el as any).name }, [el]),
+    })
+
+    // We expect:
+    // - <p> created from elementMap then wrapped => <div data-tag="p"><p>...</p></div>
+    // - <br> inserted between lines then wrapped => <div data-tag="br"><br></div>
+    expect(html(out)).toEqual(
+      '<div data-tag="p"><p>a<div data-tag="br"><br></div>b</p></div>',
+    )
+  })
+
+  it('applies transformText to top-level Text nodes produced by conversion', () => {
+    const config: Config = {
+      markMap: { bold: ['strong'] },
+      elementMap: {},
+      elementTransforms: {},
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: 't' },
+      config,
+      transformText: (n) => {
+        return n instanceof Text ? new Text(`[${n.data}]`) : n
+      },
+    })
+
+    expect(html(out)).toEqual('[t]')
+  })
+
+  it('wrapChildren controls the container for text-node conversions', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {},
+      elementTransforms: {},
+    }
+
+    const out = convertSlate({
+      node: { text: 'x' },
+      config,
+      wrapChildren: (children) => new Element('span', { id: 'wrapped' }, children),
+    })
+
+    expect(html(out)).toEqual('<span id="wrapped">x</span>')
+  })
 })
 

--- a/packages/dom/src/lib/utilities/convert-slate.spec.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.spec.ts
@@ -379,5 +379,86 @@ describe('convertSlate', () => {
 
     expect(html(out)).toEqual('<div>x</div>')
   })
+
+  it('falls back when customElementTransforms[type] returns undefined', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {
+        p: 'p',
+      },
+      elementTransforms: {
+        p: ({ children = [] }) => new Element('div', {}, children),
+      },
+    }
+
+    const out = convertSlate({
+      node: { type: 'p', children: [{ text: 'x' }] },
+      config,
+      customElementTransforms: {
+        p: () => undefined,
+      },
+    })
+
+    // Falls back to elementTransforms (since custom returned undefined)
+    expect(html(out)).toEqual('<div>x</div>')
+  })
+
+  it('splits multiline marked text into separately wrapped lines with <br> between', () => {
+    const config: Config = {
+      markMap: {
+        bold: ['strong'],
+      },
+      elementMap: {},
+      elementTransforms: {},
+      convertLineBreakToBr: true,
+    }
+
+    const out = convertSlate({
+      node: { text: 'a\nb', bold: true },
+      config,
+    })
+
+    expect(html(out)).toEqual('<strong>a</strong><br><strong>b</strong>')
+  })
+
+  it('alwaysEncodeBreakingEntities encodes Text.data when encodeEntities is false', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {},
+      elementTransforms: {},
+      encodeEntities: false,
+      alwaysEncodeBreakingEntities: true,
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: '2 & 1 < 3 > 0' },
+      config,
+    }) as unknown as Document
+
+    expect(out.children).toHaveLength(1)
+    const text = out.children[0] as Text
+    expect(text.data).toEqual('2 &amp; 1 &lt; 3 &gt; 0')
+  })
+
+  it('does not pre-encode breaking entities when encodeEntities is true', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {},
+      elementTransforms: {},
+      encodeEntities: true,
+      alwaysEncodeBreakingEntities: true,
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: '2 & 1 < 3 > 0' },
+      config,
+    }) as unknown as Document
+
+    expect(out.children).toHaveLength(1)
+    const text = out.children[0] as Text
+    expect(text.data).toEqual('2 & 1 < 3 > 0')
+  })
 })
 

--- a/packages/dom/src/lib/utilities/convert-slate.spec.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.spec.ts
@@ -89,5 +89,75 @@ describe('convertSlate', () => {
     expect(html(first)).toEqual('a<br>')
     expect(html(last)).toEqual('b')
   })
+
+  it('applies elementAttributeTransform to mapped elements', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: { p: 'p' },
+      elementTransforms: {},
+      elementAttributeTransform: ({ node }: { node: any }) => {
+        return node.id ? { 'data-id': String(node.id) } : undefined
+      },
+    }
+
+    const out = convertSlate({
+      node: { type: 'p', id: 123, children: [{ text: 'x' }] },
+      config,
+    })
+
+    expect(html(out)).toEqual('<p data-id="123">x</p>')
+  })
+
+  it('splits text on \\n into <br> when convertLineBreakToBr is enabled', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {},
+      elementTransforms: {},
+      convertLineBreakToBr: true,
+    }
+
+    const out = convertSlate({
+      node: { text: 'a\nb' },
+      config,
+    })
+
+    expect(html(out)).toEqual('a<br>b')
+  })
+
+  it('uses defaultTag for nodes without type', () => {
+    const config: Config = {
+      markMap: {},
+      elementMap: {},
+      elementTransforms: {},
+      defaultTag: 'p',
+    }
+
+    const out = convertSlate({
+      node: { children: [{ text: 'hi' }] },
+      config,
+    })
+
+    expect(html(out)).toEqual('<p>hi</p>')
+  })
+
+  it('nests marks in markMap order', () => {
+    const config: Config = {
+      markMap: {
+        bold: ['strong'],
+        italic: ['i'],
+      },
+      elementMap: {},
+      elementTransforms: {},
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: 't', bold: true, italic: true },
+      config,
+    })
+
+    // markMap iteration order is the insertion order of keys: bold then italic.
+    expect(html(out)).toEqual('<strong><i>t</i></strong>')
+  })
 })
 

--- a/packages/dom/src/lib/utilities/convert-slate.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.ts
@@ -180,10 +180,16 @@ const convertSlateElementNode = ({
 
   // more complex transforms
   if (customElementTransforms && customElementTransforms[node.type]) {
-    return customElementTransforms[node.type]({ node, attribs, children })
+    const custom = customElementTransforms[node.type]({ node, attribs, children })
+    if (custom) {
+      return custom
+    }
   }
   if (config.elementTransforms[node.type]) {
-    return transformElement(config.elementTransforms[node.type]({ node, attribs, children }) as Element)
+    const transformed = config.elementTransforms[node.type]({ node, attribs, children }) as Element | undefined
+    if (transformed) {
+      return transformElement(transformed)
+    }
   }
 
   // straightforward node to element mapping

--- a/packages/dom/src/lib/utilities/convert-slate.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.ts
@@ -56,6 +56,23 @@ const convertSlateChildren = ({
     : []
 }
 
+const appendTrailingBrIfNeeded = ({
+  children,
+  config,
+  isLastNodeInDocument,
+  transformElement,
+}: {
+  children: any[]
+  config: Config
+  isLastNodeInDocument: boolean
+  transformElement: TransformElement
+}) => {
+  // Add a line break between inline nodes when converting a list of siblings (e.g. top-level blocks).
+  if (config.convertLineBreakToBr && !isLastNodeInDocument) {
+    children.push(transformElement(new Element('br', {})))
+  }
+}
+
 const getAttribs = (node: any, config: Config): { [key: string]: string } => {
   if (!config.elementAttributeTransform) {
     return {}
@@ -216,10 +233,7 @@ export const convertSlate = ({
     return element
   }
 
-  // add line break between inline nodes
-  if (config.convertLineBreakToBr && !isLastNodeInDocument) {
-    children.push(transformElement(new Element('br', {})))
-  }
+  appendTrailingBrIfNeeded({ children, config, isLastNodeInDocument, transformElement })
 
   return wrapChildren(children)
 }

--- a/packages/dom/src/lib/utilities/convert-slate.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.ts
@@ -9,13 +9,148 @@ import { decodeBreakingEntities, encodeBreakingEntities } from '.'
 import { intersection } from '.'
 
 interface IConvertSlate {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   node: any
   config?: Config
   isLastNodeInDocument?: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   customElementTransforms?: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   transformText?: (text: Text | Element) => any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   transformElement?: (element: Element) => any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   wrapChildren?: (children: any) => any
+}
+
+type TransformText = NonNullable<IConvertSlate['transformText']>
+type TransformElement = NonNullable<IConvertSlate['transformElement']>
+type WrapChildren = NonNullable<IConvertSlate['wrapChildren']>
+
+const getAttribs = (node: any, config: Config): { [key: string]: string } => {
+  if (!config.elementAttributeTransform) {
+    return {}
+  }
+  return {
+    ...config.elementAttributeTransform({ node }),
+  }
+}
+
+const buildMarkElements = (node: any, config: Config): Element[] => {
+  const markElements: Element[] = []
+  const markTransformKeys = intersection(config.markTransforms || {}, node)
+
+  markTransformKeys.forEach((key) => {
+    if (config.markTransforms?.[key]) {
+      const markElement = config.markTransforms[key]({ node, attribs: {} })
+      if (markElement) {
+        markElements.push(markElement)
+      }
+    }
+  })
+
+  Object.keys(config.markMap).forEach((key) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((node as any)[key]) {
+      const elements: Element[] = config.markMap[key]
+        .map((tagName) => {
+          if (config.markTransforms?.[tagName]) {
+            return config.markTransforms[tagName]({ node, attribs: {} })
+          }
+          return new Element(tagName, {}, [])
+        })
+        .filter((element) => element !== undefined) as Element[]
+      markElements.push(...elements)
+    }
+  })
+
+  return markElements
+}
+
+const convertSlateTextNode = ({
+  node,
+  config,
+  transformText,
+  transformElement,
+  wrapChildren,
+}: {
+  node: any
+  config: Config
+  transformText: TransformText
+  transformElement: TransformElement
+  wrapChildren: WrapChildren
+}) => {
+  const str = config.alwaysEncodeBreakingEntities && !config.encodeEntities ? encodeBreakingEntities(node.text) : node.text
+
+  const strLines = config.convertLineBreakToBr ? str.split('\n') : [str]
+  const textChildren: (Element | Text)[] = []
+
+  // convert line breaks to br tags
+  strLines.forEach((line: string, index: number) => {
+    const markElements = buildMarkElements(node, config)
+
+    // clone markElements (it gets modified)
+    const markElementsClone = [...markElements]
+    const textElement = nestedMarkElements(markElements, new Text(line))
+
+    if (
+      config.alwaysEncodeCodeEntities &&
+      !config.encodeEntities &&
+      isTag(textElement) &&
+      getName(textElement) === 'pre'
+    ) {
+      let encodedLine = line
+      if (config.alwaysEncodeBreakingEntities) {
+        // revert the earlier encoding - encode will re-encode
+        encodedLine = decodeBreakingEntities(encodedLine)
+      }
+      textChildren.push(nestedMarkElements(markElementsClone, new Text(encode(encodedLine))))
+    } else {
+      textChildren.push(textElement)
+    }
+
+    if (index < strLines.length - 1) {
+      textChildren.push(transformElement(new Element('br', {})))
+    }
+  })
+
+  return wrapChildren(textChildren.map((child) => transformText(child)))
+}
+
+const convertSlateElementNode = ({
+  node,
+  children,
+  config,
+  customElementTransforms,
+  transformElement,
+}: {
+  node: any
+  children: any[]
+  config: Config
+  customElementTransforms: any
+  transformElement: TransformElement
+}): Element | null => {
+  const attribs = getAttribs(node, config)
+
+  // more complex transforms
+  if (customElementTransforms && customElementTransforms[node.type]) {
+    return customElementTransforms[node.type]({ node, attribs, children })
+  }
+  if (config.elementTransforms[node.type]) {
+    return transformElement(config.elementTransforms[node.type]({ node, attribs, children }) as Element)
+  }
+
+  // straightforward node to element mapping
+  if (config.elementMap[node.type]) {
+    return transformElement(new Element(config.elementMap[node.type], attribs, children))
+  }
+
+  // default tag
+  if (config.defaultTag && !node.type) {
+    return transformElement(new Element(config.defaultTag, attribs, children))
+  }
+
+  return null
 }
 
 export const convertSlate = ({
@@ -23,70 +158,12 @@ export const convertSlate = ({
   config = defaultConfig,
   isLastNodeInDocument = false,
   customElementTransforms,
-  /* tslint:disable:no-shadowed-variable */
   transformText = (text) => text,
-  /* tslint:disable:no-shadowed-variable */
   transformElement = (element) => element,
   wrapChildren = (children) => new Document(children),
 }: IConvertSlate) => {
   if (SlateText.isText(node)) {
-    const str =
-      config.alwaysEncodeBreakingEntities && !config.encodeEntities ? encodeBreakingEntities(node.text) : node.text
-
-    const strLines = config.convertLineBreakToBr ? str.split('\n') : [str]
-    const textChildren: (Element | Text)[] = []
-
-    // convert line breaks to br tags
-    strLines.forEach((line, index) => {
-      const markElements: Element[] = []
-      const markTransformKeys = intersection(config.markTransforms || {}, node)
-
-      markTransformKeys.forEach((key) => {
-        if (config.markTransforms?.[key]) {
-          const markElement = config.markTransforms[key]({ node, attribs: {} })
-          if (markElement) {
-            markElements.push(markElement)
-          }
-        }
-      })
-
-      Object.keys(config.markMap).forEach((key) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        if ((node as any)[key]) {
-          const elements: Element[] = config.markMap[key].map((tagName) => {
-            if (config.markTransforms?.[tagName]) {
-              return config.markTransforms[tagName]({ node, attribs: {} })
-            }
-            return new Element(tagName, {}, [])
-          }).filter((element) => element !== undefined) as Element[]
-          markElements.push(...elements)
-        }
-      })
-      // clone markElements (it gets modified)
-      const markElementsClone = [...markElements]
-      const textElement = nestedMarkElements(markElements, new Text(line))
-
-      if (
-        config.alwaysEncodeCodeEntities &&
-        !config.encodeEntities &&
-        isTag(textElement) &&
-        getName(textElement) === 'pre'
-      ) {
-        if (config.alwaysEncodeBreakingEntities) {
-          // revert the earlier encoding - encode will re-encode
-          line = decodeBreakingEntities(line)
-        }
-        textChildren.push(nestedMarkElements(markElementsClone, new Text(encode(line))))
-      } else {
-        textChildren.push(textElement)
-      }
-
-      if (index < strLines.length - 1) {
-        textChildren.push(transformElement(new Element('br', {})))
-      }
-    })
-
-    return wrapChildren(textChildren.map((child) =>  transformText(child)))
+    return convertSlateTextNode({ node, config, transformText, transformElement, wrapChildren })
   }
 
   const children: any[] = node.children
@@ -102,33 +179,13 @@ export const convertSlate = ({
       )
     : []
 
-  let attribs: { [key: string]: string } = {}
-
-  if (config.elementAttributeTransform) {
-    attribs = {
-      ...attribs,
-      ...config.elementAttributeTransform({ node }),
-    }
-  }
-
-  let element: Element | null = null
-
-  // more complex transforms
-  if (customElementTransforms && customElementTransforms[node.type]) {
-    element = customElementTransforms[node.type]({ node, attribs, children })
-  } else if (config.elementTransforms[node.type]) {
-    element = transformElement(config.elementTransforms[node.type]({ node, attribs, children }) as Element)
-  }
-
-  // straightforward node to element mapping
-  if (!element && config.elementMap[node.type]) {
-    element = transformElement(new Element(config.elementMap[node.type], attribs, children))
-  }
-
-  // default tag
-  if (!element && config.defaultTag && !node.type) {
-    element = transformElement(new Element(config.defaultTag, attribs, children))
-  }
+  const element = convertSlateElementNode({
+    node,
+    children,
+    config,
+    customElementTransforms,
+    transformElement,
+  })
 
   if (element) {
     return element

--- a/packages/dom/src/lib/utilities/convert-slate.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.ts
@@ -27,6 +27,35 @@ type TransformText = NonNullable<IConvertSlate['transformText']>
 type TransformElement = NonNullable<IConvertSlate['transformElement']>
 type WrapChildren = NonNullable<IConvertSlate['wrapChildren']>
 
+const convertSlateChildren = ({
+  node,
+  config,
+  customElementTransforms,
+  transformText,
+  transformElement,
+  wrapChildren,
+}: {
+  node: any
+  config: Config
+  customElementTransforms: any
+  transformText: TransformText
+  transformElement: TransformElement
+  wrapChildren: WrapChildren
+}): any[] => {
+  return node.children
+    ? node.children.map((n: any[]) =>
+        convertSlate({
+          node: n,
+          config,
+          customElementTransforms,
+          transformText,
+          transformElement,
+          wrapChildren,
+        }),
+      )
+    : []
+}
+
 const getAttribs = (node: any, config: Config): { [key: string]: string } => {
   if (!config.elementAttributeTransform) {
     return {}
@@ -166,18 +195,14 @@ export const convertSlate = ({
     return convertSlateTextNode({ node, config, transformText, transformElement, wrapChildren })
   }
 
-  const children: any[] = node.children
-    ? node.children.map((n: any[]) =>
-        convertSlate({
-          node: n,
-          config,
-          customElementTransforms,
-          transformText,
-          transformElement,
-          wrapChildren,
-        }),
-      )
-    : []
+  const children = convertSlateChildren({
+    node,
+    config,
+    customElementTransforms,
+    transformText,
+    transformElement,
+    wrapChildren,
+  })
 
   const element = convertSlateElementNode({
     node,

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -11,6 +11,7 @@
   },
   "exclude": [
     "jest.config.ts",
+    "src/**/__tests__/**",
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.tsx",


### PR DESCRIPTION


Improve maintainability and release readiness across the monorepo by refactoring the Slate→DOM conversion pipeline, hardening behavior with new focused unit tests, and ensuring test artifacts are not shipped in production bundles.

## Highlights

- **Maintainability refactor**: `convertSlate` was split into small, named helpers and reorganized for readability while keeping behavior consistent.
- **Bug fix (fallback behavior)**: Fixed an edge case where `elementTransforms[type]` (or `customElementTransforms[type]`) returning `undefined` prevented expected fallback to `elementMap` / `defaultTag`. This is now correctly handled.
- **Improved test coverage**: Added targeted `convertSlate` tests that lock in transform precedence, encoding/line-break behavior, attribute handling, and hook semantics (without requiring integration-style fixtures).
- **Production bundle hygiene**: Confirmed dist outputs do not include test files. Updated React build configuration to exclude `src/**/__tests__/**` from the library build and verified a clean `dist/` after rebuild.

## Notes

- No breaking public API changes are intended; this work primarily improves internal structure, correctness in a fallback edge case, and confidence via tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating conversion functionality across various configurations, edge cases, and transformation pipelines.

* **Refactor**
  * Improved internal code organization and structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->