### PR TITLE
fix(react): preserve CSS styles and nested marks in SlateToReact

### DIFF
--- a/packages/dom/src/lib/dom.ts
+++ b/packages/dom/src/lib/dom.ts
@@ -19,4 +19,4 @@ export { Element, Text } from 'domhandler'
 // Slate to DOM utilities
 export { convertSlate } from './utilities/convert-slate'
 export { extractCssFromStyle } from './utilities/domhandler'
-export { isEmptyObject, styleMapToAttribs } from './utilities'
+export { isEmptyObject, parseStyleCssText, styleMapToAttribs } from './utilities'

--- a/packages/dom/src/lib/utilities/index.ts
+++ b/packages/dom/src/lib/utilities/index.ts
@@ -12,16 +12,29 @@ export const parseStyleCssText = (value: string): { [key: string]: string } => {
     return output
   }
 
-  const style = value.split(';')
+  // At-rules (e.g. @media) are not representable as React inline style props.
+  const withoutAtRules = value.replace(/@[^{]+\{[^}]*\}/g, '')
 
-  for (const s of style) {
+  for (const s of withoutAtRules.split(';')) {
     const rule = s.trim()
-
-    if (rule) {
-      const ruleParts = rule.split(':')
-      const key = camelize(ruleParts[0].trim())
-      output[key] = ruleParts[1].trim()
+    if (!rule) {
+      continue
     }
+
+    const separatorIndex = rule.indexOf(':')
+    if (separatorIndex === -1) {
+      continue
+    }
+
+    const rawKey = rule.slice(0, separatorIndex).trim()
+    const rawValue = rule.slice(separatorIndex + 1).trim()
+    if (!rawKey || !rawValue) {
+      continue
+    }
+
+    // Preserve CSS custom properties; camelize would mangle `--text-color`.
+    const key = rawKey.startsWith('--') ? rawKey : camelize(rawKey)
+    output[key] = rawValue
   }
 
   return output

--- a/packages/dom/src/lib/utilities/parse-style-css-text.spec.ts
+++ b/packages/dom/src/lib/utilities/parse-style-css-text.spec.ts
@@ -1,0 +1,28 @@
+import { parseStyleCssText } from '.'
+
+describe('parseStyleCssText', () => {
+  it('camelizes standard CSS properties', () => {
+    expect(parseStyleCssText('text-align:right;font-size:16px')).toEqual({
+      textAlign: 'right',
+      fontSize: '16px',
+    })
+  })
+
+  it('preserves CSS custom properties', () => {
+    expect(parseStyleCssText('--text-color: #DD3A0A; color: red')).toEqual({
+      '--text-color': '#DD3A0A',
+      color: 'red',
+    })
+  })
+
+  it('strips at-rules that cannot map to React inline styles', () => {
+    expect(
+      parseStyleCssText(
+        'font-size: 96px; --text-color: #DD3A0A; @media screen { z-index: 1; color: var(--text-color) }',
+      ),
+    ).toEqual({
+      fontSize: '96px',
+      '--text-color': '#DD3A0A',
+    })
+  })
+})

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -60,12 +60,24 @@ import { SlateToReact, payloadSlateToReactConfig } from '@slate-serializers/reac
 
 ### `markTransforms` vs `markMap`
 
-Internally, `SlateToReact` runs the shared DOM converter with **DOM** `elementTransforms` / `markTransforms` cleared so that **block-level** output is driven only by your **React** `elementTransforms`. **Inline marks** use **`markMap`** (and the default DOM behavior for simple tags), not the DOM serializer’s `markTransforms`.
+`SlateToReact` clears **DOM** `elementTransforms` so **block-level** output is driven by your **React** `elementTransforms` (returning `ReactNode`). **Inline marks** use **`markMap`** for simple tags, and optional **`markTransforms`** that return `domhandler` `Element`s (same shape as `@slate-serializers/html` / `@slate-serializers/dom`). Those elements are then converted to React, including attributes such as `style`.
 
-- For **custom per-mark DOM** logic (returning `new Element(...)`), use **`slateToHtml`** from `@slate-serializers/html`.
-- For **React** output, prefer **`markMap`** and, where needed, custom **`elementTransforms`** for blocks.
+CSS `style` strings on elements (from `elementAttributeTransform` or `markTransforms`) are parsed into React style objects automatically.
 
-See the demo section [“Custom DOM `markTransforms`…”](https://thompsonsj.github.io/slate-serializers-demo/slate-to-react/docs) for a concrete explanation.
+```tsx
+import { Element } from '@slate-serializers/dom'
+import { type SlateToReactConfig, slateToReactConfig } from '@slate-serializers/react'
+
+const config: SlateToReactConfig = {
+  ...slateToReactConfig,
+  markTransforms: {
+    style: ({ node }) =>
+      new Element('span', {
+        style: `color: ${node.style?.color};`,
+      }),
+  },
+}
+```
 
 ### Example: custom block component
 

--- a/packages/react/src/lib/__tests__/#175.spec.tsx
+++ b/packages/react/src/lib/__tests__/#175.spec.tsx
@@ -38,7 +38,11 @@ describe('Issue 175', () => {
         </h3>
         Combine 
         <strong>
-          all three
+          <u>
+            <i>
+              all three
+            </i>
+          </u>
         </strong>
          of the aforementioned tags. Throw a 
         <s>
@@ -49,7 +53,9 @@ describe('Issue 175', () => {
           Heading 4: Code
         </h4>
         <pre>
-          2 &gt; 1 but is &lt; 3 &amp; it can break HTML
+          <code>
+            2 &gt; 1 but is &lt; 3 &amp; it can break HTML
+          </code>
         </pre>
         <h5>
           Heading 5: Text indent
@@ -167,7 +173,11 @@ describe('Issue 175', () => {
         <p>
           Combine 
           <strong>
-            all three
+            <u>
+              <i>
+                all three
+              </i>
+            </u>
           </strong>
            of the aforementioned tags. Throw a 
           <s>

--- a/packages/react/src/lib/__tests__/default.spec.tsx
+++ b/packages/react/src/lib/__tests__/default.spec.tsx
@@ -73,7 +73,9 @@ describe('React conversion', () => {
           </i>
            better than a 
           <pre>
-            &lt;textarea&gt;
+            <code>
+              &lt;textarea&gt;
+            </code>
           </pre>
           !
         </p>

--- a/packages/react/src/lib/__tests__/style.spec.tsx
+++ b/packages/react/src/lib/__tests__/style.spec.tsx
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import { Element } from '@slate-serializers/dom'
+import { SlateToReact } from '../react'
+import { config as defaultReactConfig } from '../config/default'
+import type { Config as SlateToReactConfig } from '../config/types'
+
+describe('SlateToReact style attributes', () => {
+  it('applies default align as a React style object', () => {
+    const slate = [
+      {
+        type: 'p',
+        align: 'right',
+        children: [{ text: 'Aligned' }],
+      },
+    ]
+
+    const { container } = render(<SlateToReact node={slate} />)
+    expect(container.querySelector('p')).toHaveAttribute('style', expect.stringContaining('text-align: right'))
+  })
+
+  it('converts CSS style strings from elementAttributeTransform', () => {
+    const config: SlateToReactConfig = {
+      ...defaultReactConfig,
+      elementAttributeTransform: () => ({
+        style: 'color: red; font-size: 20px',
+      }),
+    }
+
+    const slate = [
+      {
+        type: 'p',
+        children: [{ text: 'Colored' }],
+      },
+    ]
+
+    const { container } = render(<SlateToReact node={slate} config={config} />)
+    const style = container.querySelector('p')?.getAttribute('style') || ''
+    expect(style).toContain('color: red')
+    expect(style).toContain('font-size: 20px')
+  })
+
+  it('applies mark style transforms as React style objects', () => {
+    const config: SlateToReactConfig = {
+      ...defaultReactConfig,
+      markTransforms: {
+        style: ({ node }) =>
+          new Element('span', {
+            style: `color: ${(node as { style?: { color?: string } }).style?.color};`,
+          }),
+      },
+    }
+
+    const slate = [
+      {
+        type: 'p',
+        children: [
+          {
+            text: 'Highlighted',
+            style: { color: 'red' },
+          },
+        ],
+      },
+    ]
+
+    const { container } = render(<SlateToReact node={slate} config={config} />)
+    expect(container.querySelector('span')).toHaveAttribute('style', expect.stringContaining('color: red'))
+  })
+})

--- a/packages/react/src/lib/config/types.ts
+++ b/packages/react/src/lib/config/types.ts
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react'
-import { BaseConfig } from '@slate-serializers/dom'
+import { BaseConfig, MarkTransform } from '@slate-serializers/dom'
 
-interface MarkTagTransform {
-  [key: string]: ({ node, attribs }: { node?: any; attribs?: { [key: string]: string } }) => ReactNode
+interface MarkTransforms {
+  [key: string]: MarkTransform
 }
 
 interface ElementTagTransform {
@@ -11,6 +11,7 @@ interface ElementTagTransform {
     attribs,
     children,
   }: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     node?: any
     attribs?: { [key: string]: string }
     children?: ReactNode
@@ -18,6 +19,11 @@ interface ElementTagTransform {
 }
 
 export interface Config extends BaseConfig {
-  markTransforms?: MarkTagTransform
+  /**
+   * Mark transforms must return domhandler `Element`s. They are applied during
+   * Slate→DOM conversion, then converted to React elements (including attributes
+   * such as `style`).
+   */
+  markTransforms?: MarkTransforms
   elementTransforms: ElementTagTransform
 }

--- a/packages/react/src/lib/serializers.tsx
+++ b/packages/react/src/lib/serializers.tsx
@@ -1,8 +1,8 @@
-import React, { Fragment, ReactElement, JSXElementConstructor } from 'react'
+import React, { CSSProperties, Fragment, ReactElement, JSXElementConstructor, ReactNode } from 'react'
 import { Element, isTag, Text } from 'domhandler'
 import { getName, textContent } from 'domutils'
 
-import { convertSlate } from '@slate-serializers/dom'
+import { convertSlate, parseStyleCssText } from '@slate-serializers/dom'
 import { config as slateToReactConfig } from './config/default'
 import type { Config as SlateToReactConfig } from './config/types'
 
@@ -25,9 +25,17 @@ export const SlateToReact = ({ node, config = slateToReactConfig }: ISlateToReac
           {convertSlate({
             node: n,
             config: {
-              ...config,
+              markMap: config.markMap,
+              elementMap: config.elementMap,
+              elementAttributeTransform: config.elementAttributeTransform,
+              defaultTag: config.defaultTag,
+              encodeEntities: config.encodeEntities,
+              alwaysEncodeBreakingEntities: config.alwaysEncodeBreakingEntities,
+              alwaysEncodeCodeEntities: config.alwaysEncodeCodeEntities,
+              convertLineBreakToBr: config.convertLineBreakToBr,
+              markTransforms: config.markTransforms,
+              // elementTransforms receive React children via customElementTransforms instead.
               elementTransforms: {},
-              markTransforms: {},
             },
             isLastNodeInDocument: index === node.length - 1,
             customElementTransforms: config.elementTransforms,
@@ -43,27 +51,47 @@ export const SlateToReact = ({ node, config = slateToReactConfig }: ISlateToReac
   ) as any
 }
 
-const transformText = (text: Text | Element) => {
-  if (isTag(text as Element)) {
-    return React.createElement(getName(text as Element), {}, textContent(text as Element))
+const transformText = (node: Text | Element): ReactNode => {
+  if (isTag(node as Element)) {
+    const el = node as Element
+    const children = (el.children || []).map((child, index) => (
+      <Fragment key={index}>{transformText(child as Text | Element)}</Fragment>
+    ))
+    return domElementToReactElement(el, children)
   }
-  return <>{textContent(text as Text)}</>
+  return <>{textContent(node as Text)}</>
 }
 
-const domElementToReactElement = (element: Element): ReactElement<any, string | JSXElementConstructor<any>> => {
-  const style = element.attribs?.style && typeof element.attribs.style === 'object' && { style: element.attribs?.style }
+const styleAttributeToReactStyle = (styleAttr: unknown): CSSProperties | undefined => {
+  if (!styleAttr) {
+    return undefined
+  }
+  if (typeof styleAttr === 'object' && !Array.isArray(styleAttr)) {
+    return styleAttr as CSSProperties
+  }
+  if (typeof styleAttr === 'string') {
+    const parsed = parseStyleCssText(styleAttr)
+    return Object.keys(parsed).length > 0 ? (parsed as CSSProperties) : undefined
+  }
+  return undefined
+}
+
+const domElementToReactElement = (
+  element: Element,
+  children?: ReactNode,
+): ReactElement<any, string | JSXElementConstructor<any>> => {
+  const { style: styleAttr, class: className, ...restAttribs } = element.attribs || {}
+  const style = styleAttributeToReactStyle(styleAttr)
+
   return React.createElement(
     getName(element),
     {
       /* Keys are not set here: these nodes are not list items from .map(); random keys would remount
        * every render. List keys for top-level blocks are on Fragment wrappers in SlateToReact. */
-      /* Provide all attributes as props */
-      ...element.attribs,
-      /* Convert key names for JSX compatibility */
-      ...(element.attribs?.class && { className: element.attribs?.class }),
-      /* Validate style (can convert to React style object using elementAttributeTransform or other transform functions, but it is still possible that a string will be passed) */
-      style: style ? style : undefined,
+      ...restAttribs,
+      ...(className && { className }),
+      ...(style && { style }),
     },
-    element.children as any,
+    children !== undefined ? children : (element.children as any),
   )
 }

--- a/packages/tests/src/lib/fixtures/combined.ts
+++ b/packages/tests/src/lib/fixtures/combined.ts
@@ -17,8 +17,9 @@
  * original Slate object or our 'p' tag version.
  */
 
-// code/pre logic breaks this. Work code/pre into the text tag function in the htmlToSlate file.
-// e.g. cannot handle converting back to `<p>Install <pre><code>slate-serializers</code></pre> via npm to convert between Slate and JSON.</p>`, need to look at the way htmlparser2 handles these elements.
+// Inline `<pre>` is invalid HTML inside `<p>`; htmlparser2 will split the paragraph.
+// Default htmlToSlate config rewrites `<pre>` → `<code>` via htmlPreProcessString so
+// round-trips like `<p>…<pre><code>…</code></pre>…</p>` stay inline.
 
 interface Ifixture {
   name: string

--- a/packages/tests/src/lib/react/__snapshots__/combined-payload.spec.tsx.snap
+++ b/packages/tests/src/lib/react/__snapshots__/combined-payload.spec.tsx.snap
@@ -15,7 +15,9 @@ exports[`Slate JSON to React transforms Combined larger document 1 1`] = `
     </strong>
      with 
     <strong>
-      various
+      <i>
+        various
+      </i>
     </strong>
      text 
     <s>
@@ -206,7 +208,9 @@ exports[`Slate JSON to React transforms Text tags pre 1`] = `
 <div>
   <p>
     <pre>
-      Pre
+      <code>
+        Pre
+      </code>
     </pre>
   </p>
 </div>
@@ -236,7 +240,9 @@ exports[`Slate JSON to React transforms Text tags strong and idiomatic text 1`] 
 <div>
   <p>
     <strong>
-      Strong and Idiomatic Text
+      <i>
+        Strong and Idiomatic Text
+      </i>
     </strong>
   </p>
 </div>
@@ -246,7 +252,9 @@ exports[`Slate JSON to React transforms Text tags strong and unarticulated annot
 <div>
   <p>
     <strong>
-      Strong and Unarticulated Annotation
+      <u>
+        Strong and Unarticulated Annotation
+      </u>
     </strong>
   </p>
 </div>

--- a/packages/tests/src/lib/react/__snapshots__/combined.spec.tsx.snap
+++ b/packages/tests/src/lib/react/__snapshots__/combined.spec.tsx.snap
@@ -12,7 +12,9 @@ exports[`Slate JSON to React transforms Combined larger document 1 1`] = `
   </strong>
    with 
   <strong>
-    various
+    <i>
+      various
+    </i>
   </strong>
    text 
   <s>
@@ -191,7 +193,9 @@ exports[`Slate JSON to React transforms Text tags idiomatic text 1`] = `
 exports[`Slate JSON to React transforms Text tags pre 1`] = `
 <div>
   <pre>
-    Pre
+    <code>
+      Pre
+    </code>
   </pre>
 </div>
 `;
@@ -215,7 +219,9 @@ exports[`Slate JSON to React transforms Text tags strong 1`] = `
 exports[`Slate JSON to React transforms Text tags strong and idiomatic text 1`] = `
 <div>
   <strong>
-    Strong and Idiomatic Text
+    <i>
+      Strong and Idiomatic Text
+    </i>
   </strong>
 </div>
 `;
@@ -223,7 +229,9 @@ exports[`Slate JSON to React transforms Text tags strong and idiomatic text 1`] 
 exports[`Slate JSON to React transforms Text tags strong and unarticulated annotation 1`] = `
 <div>
   <strong>
-    Strong and Unarticulated Annotation
+    <u>
+      Strong and Unarticulated Annotation
+    </u>
   </strong>
 </div>
 `;

--- a/packages/tests/src/lib/react/__snapshots__/style-object.spec.tsx.snap
+++ b/packages/tests/src/lib/react/__snapshots__/style-object.spec.tsx.snap
@@ -3,9 +3,13 @@
 exports[`style attribute css transforms with postcss mark transform 1`] = `
 <div>
   <p>
-    <strong>
-      Paragraph
-    </strong>
+    <span
+      style="font-size: 96px; --text-color: #DD3A0A;"
+    >
+      <strong>
+        Paragraph
+      </strong>
+    </span>
   </p>
 </div>
 `;
@@ -14,17 +18,31 @@ exports[`style attribute css transforms with postcss mark transforms on multiple
 <div>
   <p>
     This is editable 
-    <strong>
-      rich
-    </strong>
+    <span
+      style="font-size: 20px; font-weight: 600; text-decoration: underline dotted;"
+    >
+      <strong>
+        rich
+      </strong>
+    </span>
      text, 
-    <i>
-      much
-    </i>
+    <span
+      style="text-decoration: underline;"
+    >
+      <i>
+        much
+      </i>
+    </span>
      better than a 
-    <pre>
-      &lt;textarea&gt;
-    </pre>
+    <span
+      style="color: red;"
+    >
+      <pre>
+        <code>
+          &lt;textarea&gt;
+        </code>
+      </pre>
+    </span>
     !
   </p>
 </div>
@@ -32,7 +50,9 @@ exports[`style attribute css transforms with postcss mark transforms on multiple
 
 exports[`style attribute css transforms with postcss p tag element transform 1`] = `
 <div>
-  <p>
+  <p
+    style="font-size: 96px; --text-color: #DD3A0A;"
+  >
     <strong>
       Paragraph
     </strong>

--- a/packages/tests/src/lib/react/style-object.spec.tsx
+++ b/packages/tests/src/lib/react/style-object.spec.tsx
@@ -1,5 +1,6 @@
-import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import { Element } from '@slate-serializers/dom'
 import { SlateToReact, slateToReactConfig as defaultReactConfig, SlateToReactConfig } from '@slate-serializers/react'
 import { styleObjectFixtures } from './../tests'
 import { transformStyleObjectToString } from '@slate-serializers/utilities'
@@ -9,7 +10,14 @@ const reactConfig: SlateToReactConfig = {
   elementAttributeTransform: ({ node }) => {
     const style = transformStyleObjectToString(node.style)
     return style ? { style } : undefined
-  }
+  },
+  markTransforms: {
+    style: ({ node }) => {
+      return new Element('span', {
+        style: transformStyleObjectToString(node.style),
+      })
+    },
+  },
 }
 
 describe('style attribute css transforms with postcss', () => {


### PR DESCRIPTION
## Summary
- Stop `SlateToReact` from wiping CSS `style` attributes: parse style strings into React style objects (fixes cases like colored/aligned text, related to #180).
- Stop clearing `markTransforms`, and convert nested mark trees to React instead of flattening them (e.g. keep `<pre><code>` nesting).
- Harden `parseStyleCssText` for CSS custom properties and strip `@media` rules that cannot map to inline styles; export it from `@slate-serializers/dom`.

## Test plan
- [x] `nx test react` / `nx test dom` / `nx test tests`
- [x] New `style.spec.tsx` coverage for align, elementAttributeTransform styles, and mark style transforms
- [x] Updated React style-object and combined snapshots show styles + nested marks
- [ ] Confirm a consumer with `style` / `align` on Slate nodes sees styles in the rendered React tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved CSS style parsing, including support for custom properties and styles containing at-rules.
  - Enhanced Slate-to-React rendering for inline styles, classes, nested formatting, and transformed marks.
  - Added support for mark transforms that produce DOM elements with styles.

- **Documentation**
  - Clarified React mark transforms, DOM conversion, and style handling.

- **Bug Fixes**
  - Corrected rendering of nested formatting and inline code content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->