### PR TITLE
chore(ci): collect and upload Jest coverage reports

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -43,7 +43,9 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: coverage/**/lcov.info,coverage/**/cobertura-coverage.xml
+        # `files` is an explicit path list (no glob expansion). Search under
+        # coverage/ so Codecov auto-discovers per-package lcov/cobertura reports.
+        directory: coverage
         flags: unittests
         name: slate-serializers
         fail_ci_if_error: false

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,4 +28,23 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test
+    - name: Test with coverage
+      run: npm run test:coverage
+    - name: Upload coverage artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-reports
+        path: coverage/**
+        if-no-files-found: warn
+        retention-days: 14
+    - name: Upload coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: coverage/**/lcov.info,coverage/**/cobertura-coverage.xml
+        flags: unittests
+        name: slate-serializers
+        fail_ci_if_error: false
+        verbose: true

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -22,4 +22,13 @@ module.exports = {
   transformIgnorePatterns: [
     `/node_modules/(?!(${esmDomStackPackages})/)`,
   ],
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.spec.{ts,tsx}',
+    '!src/**/*.test.{ts,tsx}',
+    '!src/**/__tests__/**',
+    '!src/**/fixtures/**',
+    '!src/**/__snapshots__/**',
+  ],
+  coverageReporters: ['text', 'text-summary', 'lcov', 'html', 'cobertura'],
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "test": "nx run-many --all --target=test",
+    "test:coverage": "nx run-many --all --target=test --configuration=ci",
     "build": "nx run-many --all --target=build",
     "publish": "nx deploy dom && nx deploy html && nx deploy react && nx deploy utilities && nx deploy template && nx deploy slate-serializers"
   },

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -43,7 +43,14 @@
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
-        "jestConfig": "packages/react/jest.config.ts"
+        "jestConfig": "packages/react/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
       }
     }
   }

--- a/packages/tests/jest.config.ts
+++ b/packages/tests/jest.config.ts
@@ -1,11 +1,11 @@
 /* eslint-disable */
 module.exports = {
-  displayName: 'react',
+  displayName: 'tests',
   preset: '../../jest.preset.js',
   transform: {
     '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
     '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../coverage/packages/react',
+  coverageDirectory: '../../coverage/packages/tests',
 };


### PR DESCRIPTION
## Summary
- Add `npm run test:coverage` and run it in Node.js CI with coverage reporters (`lcov`, `html`, `cobertura`).
- Fix `packages/tests` jest config (wrong `displayName` / coverage dir) and add the missing `ci` coverage config on `react`.
- Upload coverage as a CI artifact and to Codecov via `CODECOV_TOKEN`.

## Test plan
- [x] `npm run test:coverage` passes locally
- [ ] CI run uploads `coverage-reports` artifact
- [ ] Codecov receives the upload (check Actions log + Codecov dashboard for this PR)
- [ ] Optional: confirm Codecov PR comment appears after the first successful upload


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a dedicated test coverage command for CI runs.
  * Expanded coverage reporting with text, HTML, LCOV, and Cobertura formats.
  * Improved test handling when no tests are present.
  * Corrected test project labeling and coverage output locations.

* **Chores**
  * CI now collects, archives, and uploads test coverage reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->