### PR TITLE
Increase test coverage and fix encoding/mark/htmlUpdater bugs

### DIFF
--- a/packages/dom/src/lib/utilities/convert-slate.spec.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.spec.ts
@@ -67,6 +67,63 @@ describe('convertSlate', () => {
     expect(text.data).toEqual('2 &amp; 1 &lt; 3 &gt; 0')
   })
 
+  it('encodes entities when markMap uses only <code> (outermost is not <pre>)', () => {
+    const config: Config = {
+      markMap: {
+        code: ['code'],
+      },
+      elementMap: {},
+      elementTransforms: {},
+      encodeEntities: false,
+      alwaysEncodeBreakingEntities: false,
+      alwaysEncodeCodeEntities: true,
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: '2 & 1 < 3 > 0', code: true },
+      config,
+    }) as unknown as Document
+
+    const code = out.children[0] as Element
+    expect(getName(code)).toEqual('code')
+    const text = code.children[0] as Text
+    expect(text.data).toEqual('2 &amp; 1 &lt; 3 &gt; 0')
+  })
+
+  it('encodes entities when a style mark wraps outside <pre>/<code>', () => {
+    const config: Config = {
+      markMap: {
+        code: ['pre', 'code'],
+      },
+      markTransforms: {
+        style: ({ node }) =>
+          new Element('span', {
+            style: `color:${(node as { style?: { color?: string } }).style?.color};`,
+          }),
+      },
+      elementMap: {},
+      elementTransforms: {},
+      encodeEntities: false,
+      alwaysEncodeBreakingEntities: false,
+      alwaysEncodeCodeEntities: true,
+      convertLineBreakToBr: false,
+    }
+
+    const out = convertSlate({
+      node: { text: '<textarea>', code: true, style: { color: 'red' } },
+      config,
+    }) as unknown as Document
+
+    // Assert on Text.data — serializer would double-escape already-encoded entities.
+    const span = out.children[0] as Element
+    expect(getName(span)).toEqual('span')
+    const pre = span.children[0] as Element
+    const code = pre.children[0] as Element
+    const text = code.children[0] as Text
+    expect(text.data).toEqual('&lt;textarea&gt;')
+  })
+
   it('adds a trailing <br> between sibling inline nodes when enabled', () => {
     const config: Config = {
       markMap: {},

--- a/packages/dom/src/lib/utilities/convert-slate.ts
+++ b/packages/dom/src/lib/utilities/convert-slate.ts
@@ -1,4 +1,4 @@
-import { Document, Element, isTag, Text } from 'domhandler'
+import { ChildNode, Document, Element, isTag, Text } from 'domhandler'
 import { getName } from 'domutils'
 import { encode } from 'html-entities'
 import { Text as SlateText } from 'slate'
@@ -113,6 +113,20 @@ const buildMarkElements = (node: any, config: Config): Element[] => {
   return markElements
 }
 
+/** True when a mark wrapper chain includes <pre> or <code> (not only when the outermost tag is <pre>). */
+const markTreeContainsCodeOrPre = (element: Element | Text): boolean => {
+  let current: Element | Text | ChildNode | undefined = element
+  while (current && isTag(current as Element)) {
+    const el = current as Element
+    const name = getName(el)
+    if (name === 'pre' || name === 'code') {
+      return true
+    }
+    current = el.children?.[0]
+  }
+  return false
+}
+
 const convertSlateTextNode = ({
   node,
   config,
@@ -143,7 +157,7 @@ const convertSlateTextNode = ({
       config.alwaysEncodeCodeEntities &&
       !config.encodeEntities &&
       isTag(textElement) &&
-      getName(textElement) === 'pre'
+      markTreeContainsCodeOrPre(textElement)
     ) {
       let encodedLine = line
       if (config.alwaysEncodeBreakingEntities) {

--- a/packages/dom/src/lib/utilities/domhandler.spec.ts
+++ b/packages/dom/src/lib/utilities/domhandler.spec.ts
@@ -1,0 +1,50 @@
+import { Element, Text } from 'domhandler'
+import serializer from 'dom-serializer'
+import { getName } from 'domutils'
+
+import { extractCssFromStyle, nestedMarkElements, nestedMarkElementsString } from './domhandler'
+
+describe('nestedMarkElements', () => {
+  it('returns the text node when there are no mark wrappers', () => {
+    const text = new Text('plain')
+    expect(nestedMarkElements([], text)).toBe(text)
+  })
+
+  it('wraps text in a single mark element', () => {
+    const strong = new Element('strong', {}, [])
+    const out = nestedMarkElements([strong], new Text('x'))
+    expect(getName(out as Element)).toEqual('strong')
+    expect(serializer(out)).toEqual('<strong>x</strong>')
+  })
+
+  it('wraps text in more than five mark elements (regression for #181/#183)', () => {
+    const els = Array.from({ length: 6 }, (_, i) => new Element(`s${i}`, {}, []))
+    const out = nestedMarkElements([...els], new Text('deep'))
+    expect(serializer(out)).toEqual('<s0><s1><s2><s3><s4><s5>deep</s5></s4></s3></s2></s1></s0>')
+  })
+
+  it('wraps text in ten mark elements', () => {
+    const els = Array.from({ length: 10 }, (_, i) => new Element(`m${i}`, {}, []))
+    const html = nestedMarkElementsString([...els], 'x')
+    expect(html.startsWith('<m0>')).toBe(true)
+    expect(html.endsWith('</m0>')).toBe(true)
+    expect(html).toContain('>x<')
+  })
+})
+
+describe('extractCssFromStyle', () => {
+  it('returns null when the element has no style attribute', () => {
+    expect(extractCssFromStyle(new Element('p', {}, []), 'textAlign')).toBeNull()
+  })
+
+  it('looks up camelCase keys from kebab-case CSS text', () => {
+    const el = new Element('p', { style: 'text-align:right;color:red;' }, [])
+    expect(extractCssFromStyle(el, 'textAlign')).toEqual('right')
+    expect(extractCssFromStyle(el, 'color')).toEqual('red')
+  })
+
+  it('returns null when the property is missing', () => {
+    const el = new Element('p', { style: 'color:red;' }, [])
+    expect(extractCssFromStyle(el, 'textAlign')).toBeNull()
+  })
+})

--- a/packages/dom/src/lib/utilities/domhandler.ts
+++ b/packages/dom/src/lib/utilities/domhandler.ts
@@ -4,11 +4,9 @@ import serializer from 'dom-serializer'
 import { parseStyleCssText } from '.'
 
 /**
- * Generate nested mark elements
- *
- * nestedMarkElements should be recursive, but it works
- * so leaving it for now. Can handle a maximum of 5
- * elements. Really shouldn't be any more than that!
+ * Nest mark elements around text (or an inner element) by repeatedly wrapping
+ * the current node as the sole child of the next mark element.
+ * Depth is unbounded — callers may pass more than five marks.
  */
 
 export const nestedMarkElementsString = (els: Element[], text: string) => {

--- a/packages/dom/src/lib/utilities/index.spec.ts
+++ b/packages/dom/src/lib/utilities/index.spec.ts
@@ -1,0 +1,63 @@
+import { styleMapToAttribs, styleToString, isEmptyObject, encodeBreakingEntities, decodeBreakingEntities, intersection } from './index'
+
+describe('styleToString', () => {
+  it('converts camelCase keys to kebab-case CSS', () => {
+    expect(styleToString({ textAlign: 'right', fontSize: '16px' })).toEqual(
+      'text-align:right;font-size:16px;',
+    )
+  })
+})
+
+describe('isEmptyObject', () => {
+  it('detects plain empty objects', () => {
+    expect(isEmptyObject({})).toBe(true)
+    expect(isEmptyObject({ a: 1 })).toBe(false)
+    expect(isEmptyObject(null)).toBeFalsy()
+  })
+})
+
+describe('styleMapToAttribs', () => {
+  it('returns an empty object when no mapped styles are present', () => {
+    expect(
+      styleMapToAttribs({
+        elementStyleMap: { align: 'textAlign' },
+        node: { type: 'p' },
+      }),
+    ).toEqual({})
+  })
+
+  it('builds a style attribute from mapped slate keys', () => {
+    expect(
+      styleMapToAttribs({
+        elementStyleMap: { align: 'textAlign', color: 'color' },
+        node: { align: 'center', color: 'red' },
+      }),
+    ).toEqual({
+      style: 'text-align:center;color:red;',
+    })
+  })
+
+  it('skips falsy css values', () => {
+    expect(
+      styleMapToAttribs({
+        elementStyleMap: { align: 'textAlign' },
+        node: { align: '' },
+      }),
+    ).toEqual({})
+  })
+})
+
+describe('encodeBreakingEntities / decodeBreakingEntities', () => {
+  it('round-trips & < >', () => {
+    const raw = '2 & 1 < 3 > 0'
+    const encoded = encodeBreakingEntities(raw)
+    expect(encoded).toEqual('2 &amp; 1 &lt; 3 &gt; 0')
+    expect(decodeBreakingEntities(encoded)).toEqual(raw)
+  })
+})
+
+describe('intersection', () => {
+  it('returns keys present on both objects', () => {
+    expect(intersection({ a: 1, b: 2 }, { b: true, c: 3 })).toEqual(['b'])
+  })
+})

--- a/packages/html/src/lib/serializers/htmlToSlate/index.spec.ts
+++ b/packages/html/src/lib/serializers/htmlToSlate/index.spec.ts
@@ -176,3 +176,78 @@ describe('nested text formatting elements', () => {
     expect(htmlToSlate(html)).toEqual(slate)
   })
 })
+
+describe('gatherTextMarkAttributes branching', () => {
+  it('applies marks to sibling children under a shared parent', () => {
+    const html = '<p><strong><em>a</em><u>b</u></strong></p>'
+    expect(htmlToSlate(html)).toEqual([
+      {
+        type: 'p',
+        children: [
+          { text: 'a', bold: true, italic: true },
+          { text: 'b', bold: true, underline: true },
+        ],
+      },
+    ])
+  })
+
+  it('applies marks when plain text and nested marks are siblings', () => {
+    const html = '<p><strong>plain <em>nested</em></strong></p>'
+    expect(htmlToSlate(html)).toEqual([
+      {
+        type: 'p',
+        children: [
+          { text: 'plain ', bold: true },
+          { text: 'nested', bold: true, italic: true },
+        ],
+      },
+    ])
+  })
+
+  it('gathers attributes through a deep single-child mark chain', () => {
+    const html = '<p><strong><em><u><s>deep</s></u></em></strong></p>'
+    expect(htmlToSlate(html)).toEqual([
+      {
+        type: 'p',
+        children: [
+          {
+            text: 'deep',
+            bold: true,
+            italic: true,
+            underline: true,
+            strikethrough: true,
+          },
+        ],
+      },
+    ])
+  })
+})
+
+describe('htmlToSlate edge inputs', () => {
+  it('ignores comment nodes', () => {
+    expect(htmlToSlate('<!-- note --><p>Hi</p>')).toEqual([
+      {
+        type: 'p',
+        children: [{ text: 'Hi' }],
+      },
+    ])
+  })
+
+  it('treats body as a fragment wrapper (children stay nested under the fragment)', () => {
+    // htmlparser2 + slate-hyperscript leave body as an untyped fragment node.
+    expect(htmlToSlate('<body><p>One</p><p>Two</p></body>')).toEqual([
+      {
+        children: [
+          {
+            type: 'p',
+            children: [{ text: 'One' }],
+          },
+          {
+            type: 'p',
+            children: [{ text: 'Two' }],
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/packages/html/src/lib/serializers/htmlToSlate/index.ts
+++ b/packages/html/src/lib/serializers/htmlToSlate/index.ts
@@ -76,6 +76,18 @@ const deserialize = ({
     return jsx('element', attrs, children)
   }
 
+  // Text marks with nested element children (e.g. <strong><em>a</em><u>b</u></strong>)
+  // must keep sibling runs separate — do not collapse via textContent.
+  if (config.textTags[nodeName]) {
+    const hasElementChild = (currentEl.childNodes || []).some((n) => isTag(n as Element))
+    if (hasElementChild) {
+      const ownAttrs = (config.textTags[nodeName](currentEl) || {}) as Record<string, unknown>
+      return children
+        .map((child: any) => applyMarkAttrs(child, ownAttrs))
+        .filter((element: any) => element)
+    }
+  }
+
   if (config.textTags[nodeName] || el.type === ElementType.Text) {
     const attrs = gatherTextMarkAttributes({ el: currentEl,config })
     const text = processTextValue({
@@ -106,6 +118,22 @@ const deserialize = ({
   }
 
   return children
+}
+
+const applyMarkAttrs = (node: any, attrs: Record<string, unknown>): any => {
+  if (!node || typeof node !== 'object') {
+    return node
+  }
+  if (typeof node.text === 'string') {
+    return { ...attrs, ...node }
+  }
+  if (Array.isArray(node.children)) {
+    return {
+      ...node,
+      children: node.children.map((child: any) => applyMarkAttrs(child, attrs)),
+    }
+  }
+  return node
 }
 
 interface IgatherTextMarkAttributes {
@@ -154,7 +182,11 @@ export const htmlToSlate = (html: string, config: Config = defaultConfig) => {
             const updated = updater(element)
             if (updated !== null && updated !== element) {
               if (typeof updated === 'string') {
-                replaceElement(element, parseDocument(updated) as any)
+                const parsed = parseDocument(updated)
+                const replacement = getChildren(parsed).find((child) => isTag(child))
+                if (replacement) {
+                  replaceElement(element, replacement)
+                }
               } else {
                 replaceElement(element, updated)
               }

--- a/packages/html/src/lib/tests/htmlToSlate/configuration/htmlUpdaterMap.spec.ts
+++ b/packages/html/src/lib/tests/htmlToSlate/configuration/htmlUpdaterMap.spec.ts
@@ -243,4 +243,30 @@ describe('htmlToSlate configuration: htmlUpdaterMap', () => {
       ]
     `);
   });
+
+  it('replaces matched elements with a string HTML fragment from the updater', () => {
+    const html = '<p>Paragraph</p>';
+    const config: HtmlToSlateConfig = {
+      ...htmlToSlateConfig,
+      htmlUpdaterMap: {
+        p: () => '<div class="from-string"><span>Replaced</span></div>',
+      },
+      elementTags: {
+        ...htmlToSlateConfig.elementTags,
+        div: () => ({ type: 'div' }),
+        span: () => ({ type: 'span' }),
+      },
+    };
+    expect(htmlToSlate(html, config)).toEqual([
+      {
+        type: 'div',
+        children: [
+          {
+            type: 'span',
+            children: [{ text: 'Replaced' }],
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/html/src/lib/tests/slateToHtml/configuration/formatting.spec.ts
+++ b/packages/html/src/lib/tests/slateToHtml/configuration/formatting.spec.ts
@@ -174,5 +174,23 @@ describe("slateToHtml formatting", () => {
         html,
       )
     })
+
+    it('encodes code entities when markMap uses only <code>', () => {
+      const html = '<p><code>&lt;textarea&gt;</code></p>'
+      const slate = [
+        {
+          type: 'p',
+          children: [{ text: '<textarea>', code: true }],
+        },
+      ]
+      expect(
+        slateToHtml(slate, {
+          ...slateToHtmlConfig,
+          markMap: { ...slateToHtmlConfig.markMap, code: ['code'] },
+          encodeEntities: false,
+          alwaysEncodeCodeEntities: true,
+        }),
+      ).toEqual(html)
+    })
   })
 })

--- a/packages/react/src/lib/__tests__/#180.spec.tsx
+++ b/packages/react/src/lib/__tests__/#180.spec.tsx
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import { Element } from '@slate-serializers/dom'
+import { SlateToReact } from '../react'
+import { config as defaultReactConfig } from '../config/default'
+import type { Config as SlateToReactConfig } from '../config/types'
+
+/**
+ * Regression coverage for https://github.com/thompsonsj/slate-serializers/issues/180
+ * Leaf/element styles (e.g. color) should reach React as style props via transforms.
+ */
+describe('#180 leaf and element styles in SlateToReact', () => {
+  it('renders leaf style.color via markTransforms.style', () => {
+    const config: SlateToReactConfig = {
+      ...defaultReactConfig,
+      markTransforms: {
+        style: ({ node }) =>
+          new Element('span', {
+            style: `color: ${(node as { style?: { color?: string } }).style?.color};`,
+          }),
+      },
+    }
+
+    const slate = [
+      {
+        type: 'p',
+        children: [{ text: 'Painted', style: { color: '#f00' } }],
+      },
+    ]
+
+    const { container } = render(<SlateToReact node={slate} config={config} />)
+    expect(container.querySelector('span')).toHaveAttribute('style', expect.stringMatching(/color:\s*(#f00|rgb\(255,\s*0,\s*0\))/i))
+    expect(container.querySelector('span')).toHaveTextContent('Painted')
+  })
+
+  it('renders leaf color via markTransforms.color', () => {
+    const config: SlateToReactConfig = {
+      ...defaultReactConfig,
+      markTransforms: {
+        color: ({ node }) =>
+          new Element('span', {
+            style: `color:${(node as { color?: string }).color};`,
+          }),
+      },
+    }
+
+    const slate = [
+      {
+        type: 'p',
+        children: [{ text: 'Tinted', color: 'red' }],
+      },
+    ]
+
+    const { container } = render(<SlateToReact node={slate} config={config} />)
+    expect(container.querySelector('span')).toHaveAttribute('style', expect.stringContaining('color: red'))
+  })
+
+  it('renders element-level style from elementAttributeTransform', () => {
+    const config: SlateToReactConfig = {
+      ...defaultReactConfig,
+      elementAttributeTransform: ({ node }) => {
+        const style = (node as { style?: { color?: string } }).style
+        return style?.color ? { style: `color: ${style.color};` } : {}
+      },
+    }
+
+    const slate = [
+      {
+        type: 'p',
+        style: { color: 'blue' },
+        children: [{ text: 'Block colored' }],
+      },
+    ]
+
+    const { container } = render(<SlateToReact node={slate} config={config} />)
+    expect(container.querySelector('p')).toHaveAttribute('style', expect.stringContaining('color: blue'))
+  })
+})

--- a/packages/react/src/lib/__tests__/style.spec.tsx
+++ b/packages/react/src/lib/__tests__/style.spec.tsx
@@ -66,4 +66,97 @@ describe('SlateToReact style attributes', () => {
     const { container } = render(<SlateToReact node={slate} config={config} />)
     expect(container.querySelector('span')).toHaveAttribute('style', expect.stringContaining('color: red'))
   })
+
+  it('accepts style as a React style object from elementAttributeTransform', () => {
+    const config: SlateToReactConfig = {
+      ...defaultReactConfig,
+      elementAttributeTransform: () => ({
+        style: { color: 'red', fontSize: '16px' },
+      }),
+    }
+
+    const slate = [{ type: 'p', children: [{ text: 'Object style' }] }]
+    const { container } = render(<SlateToReact node={slate} config={config} />)
+    const style = container.querySelector('p')?.getAttribute('style') || ''
+    expect(style).toContain('color: red')
+    expect(style).toContain('font-size: 16px')
+  })
+
+  it('omits style when the style string is empty or whitespace', () => {
+    const config: SlateToReactConfig = {
+      ...defaultReactConfig,
+      elementAttributeTransform: () => ({
+        style: '   ',
+      }),
+    }
+
+    const slate = [{ type: 'p', children: [{ text: 'No style' }] }]
+    const { container } = render(<SlateToReact node={slate} config={config} />)
+    expect(container.querySelector('p')).not.toHaveAttribute('style')
+  })
+
+  it('ignores invalid style attribute types', () => {
+    const config: SlateToReactConfig = {
+      ...defaultReactConfig,
+      elementAttributeTransform: () => ({
+        style: 42 as unknown as string,
+      }),
+    }
+
+    const slate = [{ type: 'p', children: [{ text: 'Invalid' }] }]
+    const { container } = render(<SlateToReact node={slate} config={config} />)
+    expect(container.querySelector('p')).not.toHaveAttribute('style')
+  })
+
+  it('maps HTML class attributes to React className', () => {
+    const config: SlateToReactConfig = {
+      ...defaultReactConfig,
+      elementAttributeTransform: () => ({
+        class: 'hero',
+      }),
+    }
+
+    const slate = [{ type: 'p', children: [{ text: 'Classed' }] }]
+    const { container } = render(<SlateToReact node={slate} config={config} />)
+    expect(container.querySelector('p')).toHaveClass('hero')
+  })
+
+  it('returns an empty fragment when node is not an array', () => {
+    const { container } = render(<SlateToReact node={null as unknown as any[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('nests code marks inside a style mark', () => {
+    const config: SlateToReactConfig = {
+      ...defaultReactConfig,
+      markMap: {
+        ...defaultReactConfig.markMap,
+        code: ['code'],
+      },
+      markTransforms: {
+        style: ({ node }) =>
+          new Element('span', {
+            style: `color: ${(node as { style?: { color?: string } }).style?.color};`,
+          }),
+      },
+    }
+
+    const slate = [
+      {
+        type: 'p',
+        children: [
+          {
+            text: 'snippet',
+            code: true,
+            style: { color: 'red' },
+          },
+        ],
+      },
+    ]
+
+    const { container } = render(<SlateToReact node={slate} config={config} />)
+    const span = container.querySelector('span')
+    expect(span).toHaveAttribute('style', expect.stringContaining('color: red'))
+    expect(span?.querySelector('code')).toHaveTextContent('snippet')
+  })
 })

--- a/packages/template/src/lib/__tests__/default.spec.ts
+++ b/packages/template/src/lib/__tests__/default.spec.ts
@@ -1,6 +1,7 @@
 import { slateToTemplate } from './../serializers';
 import { config as defaultTemplateConfig } from './../config/default';
 import { Config as SlateToTemplateConfig } from './../config/types';
+import { payloadSlateToTemplateConfig } from './../template';
 
 describe('Template conversion', () => {
   test('convert domhandler element to Template', async () => {
@@ -125,5 +126,45 @@ describe('Template conversion', () => {
         [Function],
       ]
     `);
+  });
+
+  it('returns undefined when node is not an array', () => {
+    expect(slateToTemplate(null as unknown as any[])).toBeUndefined();
+  });
+
+  it('uses payloadSlateToTemplateConfig for upload nodes', () => {
+    const slate = [
+      {
+        type: 'upload',
+        value: {
+          mimeType: 'image/png',
+          url: 'https://example.com/a.png',
+        },
+        children: [{ text: '' }],
+      },
+    ];
+    const tree = slateToTemplate(slate, payloadSlateToTemplateConfig);
+    expect(tree?.[0]).toContain('img');
+    expect(tree?.[0]).toContain('https://example.com/a.png');
+  });
+
+  it('invokes customElementSerializers and returns their values', () => {
+    const config: SlateToTemplateConfig = {
+      ...defaultTemplateConfig,
+      customElementSerializers: {
+        callout: ({ node }) => `CALLOUT:${node.children?.[0]?.text}`,
+      },
+    };
+    const slate = [
+      {
+        type: 'callout',
+        children: [{ text: 'Hello' }],
+      },
+      {
+        type: 'p',
+        children: [{ text: 'Body' }],
+      },
+    ];
+    expect(slateToTemplate(slate, config)).toEqual(['CALLOUT:Hello', '<p>Body</p>']);
   });
 });

--- a/packages/tests/src/lib/fixtures/styles-in-leaf.ts
+++ b/packages/tests/src/lib/fixtures/styles-in-leaf.ts
@@ -26,4 +26,51 @@ export const fixtures: Ifixture[] = [
       }
     ]
   },
+  {
+    name: '#180 leaf color only',
+    html: '<p><span style="color:#f00;">Painted</span></p>',
+    slate: [
+      {
+        type: 'p',
+        children: [
+          {
+            color: '#f00',
+            text: 'Painted',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: '#180 leaf color with bold',
+    html: '<p><span style="color:red;"><strong>Bold red</strong></span></p>',
+    slate: [
+      {
+        type: 'p',
+        children: [
+          {
+            color: 'red',
+            bold: true,
+            text: 'Bold red',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: '#180 leaf color with code',
+    html: '<p><span style="color:green;"><pre><code>&lt;code&gt;</code></pre></span></p>',
+    slate: [
+      {
+        type: 'p',
+        children: [
+          {
+            color: 'green',
+            code: true,
+            text: '<code>',
+          },
+        ],
+      },
+    ],
+  },
 ]

--- a/packages/utilities/src/lib/style-object.spec.ts
+++ b/packages/utilities/src/lib/style-object.spec.ts
@@ -1,0 +1,37 @@
+import {
+  transformStyleObjectToString,
+  transformStyleStringToObject,
+} from './style-object'
+
+describe('transformStyleObjectToString', () => {
+  it('converts a style object to a single-line CSS string', () => {
+    const css = transformStyleObjectToString({ color: 'red', fontSize: '16px' })
+    expect(css).toContain('color: red')
+    expect(css).toContain('font-size: 16px')
+    expect(css).not.toMatch(/\n/)
+  })
+
+  it('supports nested @media style objects', () => {
+    const css = transformStyleObjectToString({
+      color: 'black',
+      '@media (min-width: 600px)': {
+        color: 'blue',
+      },
+    })
+    expect(css).toContain('@media (min-width: 600px)')
+    expect(css).toContain('color: blue')
+  })
+})
+
+describe('transformStyleStringToObject', () => {
+  it('parses a CSS string into an object', () => {
+    expect(transformStyleStringToObject('color: red; font-size: 16px')).toEqual({
+      color: 'red',
+      fontSize: '16px',
+    })
+  })
+
+  it('handles an empty string', () => {
+    expect(transformStyleStringToObject('')).toEqual({})
+  })
+})

--- a/packages/utilities/src/lib/utilities.spec.ts
+++ b/packages/utilities/src/lib/utilities.spec.ts
@@ -1,0 +1,33 @@
+import {
+  hasLineBreak,
+  prependSpace,
+  isEmptyObject,
+  removeEmpty,
+  getNested,
+} from './utilities'
+
+describe('utilities helpers', () => {
+  it('detects line breaks', () => {
+    expect(hasLineBreak('a\nb')).toBe(true)
+    expect(hasLineBreak('ab')).toBe(false)
+  })
+
+  it('prepends a trimmed space', () => {
+    expect(prependSpace('  hi ')).toEqual(' hi')
+    expect(prependSpace('')).toEqual('')
+  })
+
+  it('detects empty plain objects', () => {
+    expect(isEmptyObject({})).toBe(true)
+    expect(isEmptyObject({ a: 1 })).toBe(false)
+  })
+
+  it('removes nullish entries', () => {
+    expect(removeEmpty({ a: 1, b: null, c: undefined, d: 0 })).toEqual({ a: 1, d: 0 })
+  })
+
+  it('reads nested properties safely', () => {
+    expect(getNested({ a: { b: { c: 3 } } }, 'a', 'b', 'c')).toEqual(3)
+    expect(getNested({ a: {} }, 'a', 'b', 'c')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Raise package test coverage with high-signal unit/integration cases across `dom`, `html`, `react`, `utilities`, and `template` (bug-finding first).
- Fix `alwaysEncodeCodeEntities` so encoding applies when a mark tree contains `pre` or `code` (not only when the outermost tag is `pre`).
- Fix `htmlToSlate` so sibling nested marks (e.g. `<strong><em>a</em><u>b</u></strong>`) stay as separate text runs instead of merging attrs/text.
- Fix `htmlUpdaterMap` string replacements by using the first element child from `parseDocument` (passing a Document to `replaceElement` was a no-op).
- Lock #180 leaf/element style expectations in React and expand styles-in-leaf fixtures.

## Coverage (local Cobertura lines)
| Package | Before | After |
|---|---|---|
| dom | 75.0% | 84.4% |
| react | 88.6% | 95.5% |
| template | 52.4% | 95.2% |
| utilities | empty | 88.9% |
| html | 92.2% | 91.5%* |

\*Absolute covered lines in html rose; % dipped slightly from newly instrumented helper code.

## Test plan
- [x] `npm run test`
- [x] `npm run test:coverage`
- [ ] CI green on this PR (Node.js CI + Codecov)
- [ ] Spot-check: code-only `markMap` + `alwaysEncodeCodeEntities`
- [ ] Spot-check: sibling nested marks round-trip via `htmlToSlate`
- [ ] Spot-check: `htmlUpdaterMap` updater returning an HTML string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML-to-Slate handling for nested marks, sibling text runs, comments, document wrappers, and HTML fragments returned by custom updates.
  * Prevented double-escaping of code entities and ensured code content is encoded consistently across formatting scenarios.
  * Improved React rendering of styles, class names, nested code marks, and element attributes.
  * Enabled nested mark wrappers beyond five levels.

* **Tests**
  * Added broad coverage for conversion, formatting, styling, serialization, utility helpers, and template customization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->