### PR TITLE
fix(ci): authorize Nx Cloud in release-please publish

### DIFF
--- a/.github/workflows/release-please.js.yml
+++ b/.github/workflows/release-please.js.yml
@@ -10,19 +10,14 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: write
-  pull-requests: write
-
 name: release-please
-
-# Same Nx Cloud CI token as Node.js CI — required for nx build on this workspace.
-env:
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
@@ -35,15 +30,36 @@ jobs:
 
   publish:
     needs: release-please
+    # Normal path: release-please just created releases.
+    # Recovery path: manual dispatch from main only (not feature branches).
     if: >-
       needs.release-please.outputs.releases_created == 'true' ||
-      (github.event_name == 'workflow_dispatch' && inputs.force_publish)
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.force_publish &&
+       github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+    env:
+      # Required for nx build; scoped to publish (not the release-please job).
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      - name: Verify force-publish against existing GitHub release tags
+        if: github.event_name == 'workflow_dispatch' && inputs.force_publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          packages=(dom html react template utilities slate-serializers)
+          for pkg in "${packages[@]}"; do
+            version="$(node -p "require('./packages/${pkg}/package.json').version")"
+            tag="${pkg}-v${version}"
+            echo "Checking release tag ${tag}..."
+            gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null
+          done
+          echo "All package versions have matching GitHub release tags."
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x

--- a/.github/workflows/release-please.js.yml
+++ b/.github/workflows/release-please.js.yml
@@ -2,12 +2,23 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Force npm publish (use to recover after release tags exist but publish failed)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
   pull-requests: write
 
 name: release-please
+
+# Same Nx Cloud CI token as Node.js CI — required for nx build on this workspace.
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 jobs:
   release-please:
@@ -24,7 +35,9 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.releases_created == 'true'
+    if: >-
+      needs.release-please.outputs.releases_created == 'true' ||
+      (github.event_name == 'workflow_dispatch' && inputs.force_publish)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-please.js.yml
+++ b/.github/workflows/release-please.js.yml
@@ -46,6 +46,8 @@ jobs:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Verify force-publish against existing GitHub release tags
         if: github.event_name == 'workflow_dispatch' && inputs.force_publish
         env:


### PR DESCRIPTION
## Summary
- Set `NX_CLOUD_ACCESS_TOKEN` on the release-please workflow (same as Node.js CI) so `npm run build` can talk to Nx Cloud.
- Add `workflow_dispatch` + `force_publish` to republish when GitHub release tags already exist but the publish job failed.

## Context
Release [#238](https://github.com/thompsonsj/slate-serializers/pull/238) created GitHub tags at **2.5.5**, but npm is still at **2.5.4** because [publish failed](https://github.com/thompsonsj/slate-serializers/actions/runs/29940081739) on Nx Cloud auth.

## After merge
```bash
gh workflow run release-please.js.yml -f force_publish=true
```

## Test plan
- [ ] CI green on this PR
- [ ] After merge, run force_publish and confirm `@slate-serializers/*` on npm is 2.5.5

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release publishing workflows can now be started manually.
  * Added a “force publish” option for recovery when a prior publish attempt did not complete successfully.
* **Chores**
  * Improved recovery for manual publishing by validating that existing per-package release tags are present before running checkout, build, and publish steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->