### PR TITLE
feat(html): opt-in brStrategy for <br> conversion

### DIFF
--- a/docs/config/htmlToSlate.md
+++ b/docs/config/htmlToSlate.md
@@ -119,3 +119,31 @@ Remove any Slate JSON nodes that have no type or content. For example:
 ```
 
 These nodes may appear after [processing whitespace](../engineering.md#whitespace).
+
+### convertBrToLineBreak
+
+Default: `true`.
+
+When `true`, `<br>` tags are converted according to [`brStrategy`](#brstrategy). Set to `false` to leave `<br>` for `elementTags` (or drop them if unmapped).
+
+### brStrategy
+
+Default: `'block'`.
+
+Only applies when `convertBrToLineBreak` is `true`.
+
+| Value | Behaviour |
+| - | - |
+| `'block'` | Historical default: empty text (`''`) outside a block context; `\n` inside one. Top-level `Line 1<br>Line 2` becomes three default blocks. |
+| `'newline'` | Always `\n`; merge adjacent plain-text leaves; collapse `<br><br>` before a following block to a single `\n`. Top-level `Line 1<br>Line 2` becomes one default block with `Line 1\nLine 2`. |
+
+```ts
+import { htmlToSlate, htmlToSlateConfig } from '@slate-serializers/html'
+
+htmlToSlate('Line 1<br />Line 2', {
+  ...htmlToSlateConfig,
+  brStrategy: 'newline',
+})
+```
+
+Side-by-side fixtures: [brStrategy.spec.ts](https://github.com/thompsonsj/slate-serializers/blob/main/packages/html/src/lib/tests/htmlToSlate/configuration/brStrategy.spec.ts).

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -116,7 +116,10 @@ Note that in the default configuration, all HTML entities are encoded.
 
 ### `htmlToSlate`
 
-`br` HTML elements get special treatment. The default configuration sets `convertBrToLineBreak` to `true`, and each `br` HTML element will be converted to a text node in Slate that contains `\n`.
+`br` HTML elements get special treatment. The default configuration sets `convertBrToLineBreak` to `true`. How those breaks are represented is controlled by `brStrategy`:
+
+- **`block`** (default): historical behaviour from [#38](https://github.com/thompsonsj/slate-serializers/pull/38) — outside a block context a `<br>` becomes an empty text node (`''`, often its own block); inside a block context it becomes a `\n` text leaf.
+- **`newline`**: always emit `\n`, coalesce adjacent plain-text leaves, and collapse a run of `<br>` tags immediately before a following block element to a single `\n`. Opt in when you prefer linebreak characters over empty blocks; see [#41](https://github.com/thompsonsj/slate-serializers/issues/41).
 
 If you have schema rules that process `br` tags (e.g. in `elementTags` in the configuration), you may choose to disable this behaviour by setting `convertBrToLineBreak` to `false`.
 

--- a/packages/html/README.md
+++ b/packages/html/README.md
@@ -159,7 +159,8 @@ For more detailed documentation and examples, see [htmlToSlate | `slate-serializ
 | `elementTags` | Define transform functions for HTML element tag names. | See [default config](https://github.com/thompsonsj/slate-serializers/blob/main/packages/html/src/lib/serializers/htmlToSlate/config/default.ts). Example `{ p: () => ({ type: 'p' }), /* ... */ }`. |
 | `htmlPreProcessString` | Perform operations on the HTML string before serialization. | See [default config](https://github.com/thompsonsj/slate-serializers/blob/main/packages/html/src/lib/serializers/htmlToSlate/config/default.ts) (replaces `<pre>` with `<code>` for parsing). |
 | `filterWhitespaceNodes` | Remove whitespace that does not contribute meaning. | `true` |
-| `convertBrToLineBreak` | Convert br tags to a new line character (\n). | `true` |
+| `convertBrToLineBreak` | Convert br tags to line breaks in Slate. | `true` |
+| `brStrategy` | How converted `<br>` tags are represented: `block` (default, historical empty-block / context `\n` behavior) or `newline` (always `\n`, coalesce plain text, collapse breaks before a following block). | `'block'` |
 
 ## See also
 

--- a/packages/html/src/lib/html.ts
+++ b/packages/html/src/lib/html.ts
@@ -18,7 +18,10 @@ export {
 } from '@slate-serializers/dom'
 
 // htmlToSlate
-export type { Config as HtmlToSlateConfig } from './serializers/htmlToSlate/config/types'
+export type {
+  Config as HtmlToSlateConfig,
+  BrStrategy,
+} from './serializers/htmlToSlate/config/types'
 export { config as htmlToSlateConfig } from './serializers/htmlToSlate/config/default'
 export { config as payloadHtmlToSlateConfig } from './serializers/htmlToSlate/config/payload'
 export { config as slateDemoHtmlToSlateConfig } from './serializers/htmlToSlate/config/slateDemo'

--- a/packages/html/src/lib/serializers/htmlToSlate/brStrategy.ts
+++ b/packages/html/src/lib/serializers/htmlToSlate/brStrategy.ts
@@ -1,0 +1,137 @@
+import { ElementType } from 'htmlparser2'
+import { ChildNode, Element, isTag } from 'domhandler'
+import { getName } from 'domutils'
+
+import { isBlock } from '../../utilities/blocks'
+import { BrStrategy } from './config/types'
+import { Context } from './whitespace'
+
+/** Block tags that form document structure — not intrinsic break tags like `br`/`wbr`. */
+const isStructuralBlock = (tagName: string) =>
+  isBlock(tagName) && tagName !== 'br' && tagName !== 'wbr'
+
+const isIgnorableSibling = (node: ChildNode | null | undefined): boolean => {
+  if (!node) return false
+  if (node.type === ElementType.Text) {
+    return !/\S/.test((node as unknown as { data?: string }).data || '')
+  }
+  if (isTag(node)) {
+    const name = getName(node)
+    return name === 'br' || name === 'wbr'
+  }
+  return false
+}
+
+/** True when a later sibling (skipping whitespace / br) is a structural block element. */
+export const isFollowedByStructuralBlock = (el: Element): boolean => {
+  let sibling: ChildNode | null | undefined = el.next
+  while (sibling) {
+    if (isTag(sibling) && isStructuralBlock(getName(sibling))) {
+      return true
+    }
+    if (!isIgnorableSibling(sibling)) {
+      return false
+    }
+    sibling = sibling.next
+  }
+  return false
+}
+
+/** First `<br>` in a run that precedes a structural block (skipping whitespace). */
+export const isFirstBrBeforeStructuralBlock = (el: Element): boolean => {
+  if (!isFollowedByStructuralBlock(el)) return false
+  let sibling: ChildNode | null | undefined = el.prev
+  while (sibling) {
+    if (isTag(sibling) && getName(sibling) === 'br') {
+      return false
+    }
+    if (!isIgnorableSibling(sibling)) {
+      return true
+    }
+    sibling = sibling.prev
+  }
+  return true
+}
+
+/**
+ * Text payload for a converted `<br>`, or `null` to omit the break entirely.
+ */
+export const resolveBrText = ({
+  el,
+  context,
+  brStrategy = 'block',
+}: {
+  el: Element
+  context: Context | ''
+  brStrategy?: BrStrategy
+}): string | null => {
+  if (brStrategy === 'block') {
+    return context ? '\n' : ''
+  }
+
+  // newline: collapse a run of <br> immediately before a block to a single \n
+  if (isFollowedByStructuralBlock(el)) {
+    return isFirstBrBeforeStructuralBlock(el) ? '\n' : null
+  }
+
+  return '\n'
+}
+
+const isPlainTextLeaf = (node: unknown): node is { text: string } => {
+  if (!node || typeof node !== 'object') return false
+  const keys = Object.keys(node)
+  return keys.length === 1 && keys[0] === 'text' && typeof (node as { text: unknown }).text === 'string'
+}
+
+const isDefaultBlock = (node: unknown): node is { children: unknown[] } => {
+  if (!node || typeof node !== 'object' || !('children' in node)) return false
+  const keys = Object.keys(node)
+  return keys.length === 1 && keys[0] === 'children' && Array.isArray((node as { children: unknown[] }).children)
+}
+
+/** Merge adjacent plain-text leaves (same marks: none) so `\n` joins neighboring text. */
+export const coalescePlainTextLeaves = (nodes: unknown[]): unknown[] => {
+  const result: unknown[] = []
+  for (const node of nodes) {
+    if (node && typeof node === 'object' && Array.isArray((node as { children?: unknown[] }).children)) {
+      const element = node as { children: unknown[] }
+      result.push({
+        ...element,
+        children: coalescePlainTextLeaves(element.children),
+      })
+      continue
+    }
+    if (isPlainTextLeaf(node)) {
+      const prev = result[result.length - 1]
+      if (isPlainTextLeaf(prev)) {
+        prev.text += node.text
+        continue
+      }
+    }
+    result.push(node)
+  }
+  return result
+}
+
+/**
+ * At the document root, merge consecutive default blocks whose children are only
+ * plain text into a single block (so top-level `Line 1<br>Line 2` becomes one node).
+ */
+export const coalesceDefaultBlocks = (nodes: unknown[]): unknown[] => {
+  const coalescedChildren = coalescePlainTextLeaves(nodes)
+  const result: unknown[] = []
+
+  for (const node of coalescedChildren) {
+    if (isDefaultBlock(node) && node.children.every(isPlainTextLeaf)) {
+      const prev = result[result.length - 1]
+      if (isDefaultBlock(prev) && prev.children.every(isPlainTextLeaf)) {
+        const merged = coalescePlainTextLeaves([...prev.children, ...node.children])
+        prev.children = merged as { text: string }[]
+        continue
+      }
+    }
+    result.push(node)
+  }
+
+  return result
+}

--- a/packages/html/src/lib/serializers/htmlToSlate/config/default.ts
+++ b/packages/html/src/lib/serializers/htmlToSlate/config/default.ts
@@ -48,5 +48,6 @@ export const config: Config = {
   htmlPreProcessString: (html) => html.replace(/<pre[^>]*>/g, '<code>').replace(/<\/pre>/g, '</code>'),
   filterWhitespaceNodes: true,
   convertBrToLineBreak: true,
+  brStrategy: 'block',
   trimWhiteSpace: true,
 }

--- a/packages/html/src/lib/serializers/htmlToSlate/config/types.ts
+++ b/packages/html/src/lib/serializers/htmlToSlate/config/types.ts
@@ -12,6 +12,16 @@ export type AttributeTransform = ({
 }) => { [key: string]: unknown } | undefined
 
 /**
+ * How `<br>` tags are represented in Slate when `convertBrToLineBreak` is true.
+ *
+ * - `block` (default): preserve historical behavior — empty text (`''`) outside a
+ *   block context (often becoming its own block), `\n` inside one.
+ * - `newline`: always emit `\n` text; coalesce adjacent plain-text leaves; collapse
+ *   a run of `<br>` before a following block element to a single `\n`.
+ */
+export type BrStrategy = 'block' | 'newline'
+
+/**
  * For details on configuration options:
  * @see /docs/config/htmlToSlate.md
  */
@@ -30,6 +40,11 @@ export interface Config {
   filterWhitespaceNodes: boolean
   /* Convert br tags to a new line character (\n) */
   convertBrToLineBreak?: boolean
+  /**
+   * Strategy for converting `<br>` when `convertBrToLineBreak` is true.
+   * @default 'block'
+   */
+  brStrategy?: BrStrategy
   /* Replace multiple whitespace characters with a single space. */
   trimWhiteSpace?: boolean
 }

--- a/packages/html/src/lib/serializers/htmlToSlate/index.ts
+++ b/packages/html/src/lib/serializers/htmlToSlate/index.ts
@@ -9,6 +9,11 @@ import { Config } from './config/types'
 import { config as defaultConfig } from './config/default'
 
 import { Context, getContext, isAllWhitespace, processTextValue } from './whitespace'
+import {
+  coalesceDefaultBlocks,
+  coalescePlainTextLeaves,
+  resolveBrText,
+} from './brStrategy'
 
 import { isBlock } from '../../utilities/blocks'
 
@@ -36,10 +41,17 @@ const deserialize = ({
   const childrenContext = getContext(nodeName) || context
 
   const isLastChild = index === childrenLength - 1
-  const isWithinTextNodes = currentEl.prev?.type === ElementType.Text && currentEl.next?.type === ElementType.Text
 
   if (nodeName === 'br' && config.convertBrToLineBreak && context !== 'preserve') {
-    return [jsx('text', { text: context ? '\n' : '' }, [])]
+    const brText = resolveBrText({
+      el: currentEl,
+      context,
+      brStrategy: config.brStrategy,
+    })
+    if (brText === null) {
+      return null
+    }
+    return [jsx('text', { text: brText }, [])]
   }
 
   const children = currentEl.childNodes
@@ -59,8 +71,11 @@ const deserialize = ({
         .flat()
     : []
 
+  const maybeCoalescedChildren =
+    config.brStrategy === 'newline' ? coalescePlainTextLeaves(children) : children
+
   if (getName(currentEl) === 'body') {
-    return jsx('fragment', {}, children)
+    return jsx('fragment', {}, maybeCoalescedChildren)
   }
 
   if (config.elementTags[nodeName]) {
@@ -73,7 +88,7 @@ const deserialize = ({
       }
     }
 
-    return jsx('element', attrs, children)
+    return jsx('element', attrs, maybeCoalescedChildren)
   }
 
   // Text marks with nested element children (e.g. <strong><em>a</em><u>b</u></strong>)
@@ -82,7 +97,7 @@ const deserialize = ({
     const hasElementChild = (currentEl.childNodes || []).some((n) => isTag(n as Element))
     if (hasElementChild) {
       const ownAttrs = (config.textTags[nodeName](currentEl) || {}) as Record<string, unknown>
-      return children
+      return maybeCoalescedChildren
         .map((child: any) => applyMarkAttrs(child, ownAttrs))
         .filter((element: any) => element)
     }
@@ -117,7 +132,7 @@ const deserialize = ({
     return [jsx('text', { ...attrs, text }, [])]
   }
 
-  return children
+  return maybeCoalescedChildren
 }
 
 const applyMarkAttrs = (node: any, attrs: Record<string, unknown>): any => {
@@ -208,6 +223,10 @@ export const htmlToSlate = (html: string, config: Config = defaultConfig) => {
         })
         .filter((element) => !isSlateDeadEnd(element))
         .map((element) => addTextNodeToEmptyChildren(element))
+
+      if (config.brStrategy === 'newline') {
+        slateContent = coalesceDefaultBlocks(slateContent) as Descendant[]
+      }
     }
   })
   const parser = new Parser(handler, { decodeEntities: true })

--- a/packages/html/src/lib/tests/htmlToSlate/configuration/brStrategy.spec.ts
+++ b/packages/html/src/lib/tests/htmlToSlate/configuration/brStrategy.spec.ts
@@ -1,0 +1,178 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { htmlToSlate, htmlToSlateConfig } from '@slate-serializers/html'
+
+const blockConfig = {
+  ...htmlToSlateConfig,
+  brStrategy: 'block' as const,
+}
+
+const newlineConfig = {
+  ...htmlToSlateConfig,
+  brStrategy: 'newline' as const,
+}
+
+describe('htmlToSlate configuration: brStrategy', () => {
+  describe('top-level text with <br>', () => {
+    const html = 'Line 1<br />Line 2'
+
+    it('block (default): empty text node becomes its own block between lines', () => {
+      expect(htmlToSlate(html, blockConfig)).toEqual([
+        {
+          children: [{ text: 'Line 1' }],
+        },
+        {
+          children: [{ text: '' }],
+        },
+        {
+          children: [{ text: 'Line 2' }],
+        },
+      ])
+    })
+
+    it('newline: coalesces into a single default block with \\n in the text', () => {
+      expect(htmlToSlate(html, newlineConfig)).toEqual([
+        {
+          children: [{ text: 'Line 1\nLine 2' }],
+        },
+      ])
+    })
+  })
+
+  describe('double <br> between plain text', () => {
+    const html = 'Line 1<br /><br />Line 2'
+
+    it('block: two empty blocks between lines', () => {
+      expect(htmlToSlate(html, blockConfig)).toEqual([
+        {
+          children: [{ text: 'Line 1' }],
+        },
+        {
+          children: [{ text: '' }],
+        },
+        {
+          children: [{ text: '' }],
+        },
+        {
+          children: [{ text: 'Line 2' }],
+        },
+      ])
+    })
+
+    it('newline: single block with \\n\\n between lines', () => {
+      expect(htmlToSlate(html, newlineConfig)).toEqual([
+        {
+          children: [{ text: 'Line 1\n\nLine 2' }],
+        },
+      ])
+    })
+  })
+
+  describe('<br> inside a paragraph', () => {
+    const html = '<p>Paragraph with line<br /><br />breaks.</p>'
+
+    it('block: separate \\n text leaves (historical behavior)', () => {
+      expect(htmlToSlate(html, blockConfig)).toEqual([
+        {
+          type: 'p',
+          children: [
+            { text: 'Paragraph with line' },
+            { text: '\n' },
+            { text: '\n' },
+            { text: 'breaks.' },
+          ],
+        },
+      ])
+    })
+
+    it('newline: coalesces plain-text leaves including breaks', () => {
+      expect(htmlToSlate(html, newlineConfig)).toEqual([
+        {
+          type: 'p',
+          children: [{ text: 'Paragraph with line\n\nbreaks.' }],
+        },
+      ])
+    })
+  })
+
+  describe('<br> between marked inline and link', () => {
+    const html = '<p><strong>Line 1</strong><br /><br /><a href="/x">Line 2</a></p>'
+
+    it('block: \\n leaves between bold and link', () => {
+      expect(htmlToSlate(html, blockConfig)).toEqual([
+        {
+          type: 'p',
+          children: [
+            { bold: true, text: 'Line 1' },
+            { text: '\n' },
+            { text: '\n' },
+            {
+              type: 'link',
+              newTab: false,
+              url: '/x',
+              children: [{ text: 'Line 2' }],
+            },
+          ],
+        },
+      ])
+    })
+
+    it('newline: coalesces adjacent \\n leaves but keeps marks/elements separate', () => {
+      expect(htmlToSlate(html, newlineConfig)).toEqual([
+        {
+          type: 'p',
+          children: [
+            { bold: true, text: 'Line 1' },
+            { text: '\n\n' },
+            {
+              type: 'link',
+              newTab: false,
+              url: '/x',
+              children: [{ text: 'Line 2' }],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe('<br> run before a following block element', () => {
+    const html = 'Line 1<br /><br /><p>Line 2</p>'
+
+    it('block: empty break blocks then the paragraph', () => {
+      expect(htmlToSlate(html, blockConfig)).toEqual([
+        {
+          children: [{ text: 'Line 1' }],
+        },
+        {
+          children: [{ text: '' }],
+        },
+        {
+          children: [{ text: '' }],
+        },
+        {
+          type: 'p',
+          children: [{ text: 'Line 2' }],
+        },
+      ])
+    })
+
+    it('newline: collapses the br run to a single \\n before the paragraph', () => {
+      expect(htmlToSlate(html, newlineConfig)).toEqual([
+        {
+          children: [{ text: 'Line 1\n' }],
+        },
+        {
+          type: 'p',
+          children: [{ text: 'Line 2' }],
+        },
+      ])
+    })
+  })
+
+  it('defaults to block when brStrategy is omitted', () => {
+    const html = 'Line 1<br />Line 2'
+    expect(htmlToSlate(html, { ...htmlToSlateConfig, brStrategy: undefined })).toEqual(
+      htmlToSlate(html, blockConfig),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Closes the unfinished follow-up from #38 / #41 with an **opt-in** `brStrategy` on `htmlToSlate` (`'block'` default unchanged; `'newline'` for coalesced `\n` text).
- Side-by-side tests document the behavioral difference for top-level breaks, double `<br>`, inlines, and breaks before a following block.
- Docs updated in `packages/html/README.md`, `docs/config/htmlToSlate.md`, and `docs/engineering.md`.

## Why opt-in
Changing the default would reshape stored Slate JSON for common paste/import paths (`Line 1<br>Line 2` is three blocks today). `brStrategy: 'newline'` is the safe path for consumers who want the #41 semantics.

## Test plan
- [x] `nx test html --testPathPattern=brStrategy`
- [ ] Confirm existing `convertBrToLineBreak` tests still pass on CI
- [ ] Skim `brStrategy.spec.ts` for the block vs newline fixtures

Fixes #41

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `<br>` conversion strategies for HTML-to-Slate conversion: `block` (default) and `newline`.
  * The `newline` strategy consistently emits newline characters and merges adjacent text where appropriate.
  * Exposed the new strategy configuration type through the public API.

* **Documentation**
  * Updated configuration references and examples to explain `<br>` handling and strategy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->