### PR TITLE
chore(deps): bump postcss and pin svgo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "domutils": "^4.0.0",
         "html-entities": "^2.6.0",
         "htmlparser2": "^12.0.0",
-        "postcss": "8.5.10",
+        "postcss": "8.5.23",
         "postcss-js": "^5.1.0",
         "react": ">=16",
         "react-dom": ">=16",
@@ -16172,9 +16172,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -16191,7 +16191,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -17783,9 +17783,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19351,35 +19351,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.16",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "domutils": "^4.0.0",
     "html-entities": "^2.6.0",
     "htmlparser2": "^12.0.0",
-    "postcss": "8.5.10",
+    "postcss": "8.5.23",
     "postcss-js": "^5.1.0",
     "react": ">=16",
     "react-dom": ">=16",
@@ -94,6 +94,7 @@
     "brace-expansion": "5.0.7",
     "js-yaml": "4.3.0",
     "qs": "^6.15.3",
+    "svgo": "^3.3.4",
     "eslint": {
       "ajv": "^6.12.6"
     },


### PR DESCRIPTION
## Summary
- Bump `postcss` to `8.5.23` (source-map path security fixes).
- Pin transitive `svgo` to `^3.3.4` via `overrides` (via `@svgr/plugin-svgo`; script/JS URI hardening).
- Fresh lockfile from current `main` so `npm ci` stays in sync (including nested `typescript@5.9.3` entries Dependabot dropped).

## Why not #243
[Dependabot #243](https://github.com/thompsonsj/slate-serializers/pull/243) failed `npm ci` with `Missing: typescript@5.9.3 from lock file` — same lockfile rewrite issue as #239. Closed in favor of this PR.

## Test plan
- [x] `npm ci`
- [x] `nx run-many --all --target=test` (earlier on this branch)
- [x] `nx run-many --all --target=build`
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build tooling dependencies for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->